### PR TITLE
Update Scryfall tools for double-faced cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "before-that-resolves",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "before-that-resolves",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "license": "MIT",
       "workspaces": [
         "client",
@@ -17,7 +17,7 @@
       }
     },
     "client": {
-      "version": "0.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "axios": "^1.13.2",
         "clsx": "^2.0.0",
@@ -9087,7 +9087,7 @@
     },
     "server": {
       "name": "@before-that-resolves/server",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "dependencies": {
         "@openai/agents": "^0.3.7",
         "cors": "^2.8.5",

--- a/server/src/services/scryfall.ts
+++ b/server/src/services/scryfall.ts
@@ -180,9 +180,23 @@ export class ScryfallService {
     const imageUris =
       scryfallCard.image_uris ||
       (Array.isArray(scryfallCard.card_faces) ? scryfallCard.card_faces[0]?.image_uris : undefined);
+    const cardFaces = Array.isArray(scryfallCard.card_faces)
+      ? scryfallCard.card_faces.map((face) => ({
+        name: face.name,
+        mana_cost: face.mana_cost,
+        type_line: face.type_line,
+        oracle_text: face.oracle_text,
+        colors: face.colors,
+        power: face.power,
+        toughness: face.toughness,
+        loyalty: face.loyalty,
+        image_uris: face.image_uris
+      }))
+      : undefined;
     return {
       id: scryfallCard.id,
       name: scryfallCard.name,
+      layout: scryfallCard.layout,
       mana_cost: scryfallCard.mana_cost,
       type_line: scryfallCard.type_line,
       oracle_text: scryfallCard.oracle_text,
@@ -191,7 +205,8 @@ export class ScryfallService {
       power: scryfallCard.power,
       toughness: scryfallCard.toughness,
       loyalty: scryfallCard.loyalty,
-      image_uris: imageUris
+      image_uris: imageUris,
+      card_faces: cardFaces
     };
   }
 }
@@ -199,6 +214,7 @@ export class ScryfallService {
 type ScryfallCard = {
   id: string;
   name: string;
+  layout?: string;
   mana_cost?: string;
   type_line: string;
   oracle_text?: string;
@@ -208,7 +224,19 @@ type ScryfallCard = {
   toughness?: string;
   loyalty?: string;
   image_uris?: Record<string, string>;
-  card_faces?: Array<{ image_uris?: Record<string, string> }>;
+  card_faces?: ScryfallCardFace[];
+};
+
+type ScryfallCardFace = {
+  name?: string;
+  mana_cost?: string;
+  type_line?: string;
+  oracle_text?: string;
+  colors?: string[];
+  power?: string;
+  toughness?: string;
+  loyalty?: string;
+  image_uris?: Record<string, string>;
 };
 
 type ScryfallSearchResponse = {

--- a/server/src/tools/card-tools.test.ts
+++ b/server/src/tools/card-tools.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RunContext } from '@openai/agents';
+import type { Card } from '../types/shared';
+
+const mockSearchCardByName = vi.fn();
+const mockGetCardCollection = vi.fn();
+const mockSearchCards = vi.fn();
+const mockGetRandomCommander = vi.fn();
+const mockGetCardRulings = vi.fn();
+
+vi.mock('../services/scryfall', () => ({
+  scryfallService: {
+    searchCardByName: mockSearchCardByName,
+    getCardCollection: mockGetCardCollection,
+    searchCards: mockSearchCards,
+    getRandomCommander: mockGetRandomCommander,
+    getCardRulings: mockGetCardRulings
+  }
+}));
+
+type ToolInvoker = {
+  invoke: (runContext: RunContext<unknown>, input: string, details?: { toolCall: unknown }) => Promise<unknown>;
+};
+
+type ToolCard = {
+  name: string;
+  layout?: string;
+  manaCost?: string;
+  type: string;
+  oracleText?: string;
+  colors: string;
+  power?: string;
+  toughness?: string;
+  loyalty?: string;
+  cardFaces?: Array<{
+    name?: string;
+    manaCost?: string;
+    type?: string;
+    oracleText?: string;
+    colors?: string;
+    power?: string;
+    toughness?: string;
+    loyalty?: string;
+  }>;
+};
+
+async function invokeTool<TInput, TResult>(tool: ToolInvoker, input: TInput): Promise<TResult> {
+  return tool.invoke({} as RunContext<unknown>, JSON.stringify(input), undefined) as Promise<TResult>;
+}
+
+async function loadTools() {
+  vi.resetModules();
+  return import('./card-tools');
+}
+
+function buildDoubleFacedCard(): Card {
+  return {
+    id: 'card-1',
+    name: 'Avatar Aang // Aang, Master of Elements',
+    layout: 'transform',
+    mana_cost: undefined,
+    type_line: 'Legendary Creature — Avatar // Legendary Creature — Avatar',
+    oracle_text: undefined,
+    colors: ['W', 'U'],
+    color_identity: ['W', 'U'],
+    power: undefined,
+    toughness: undefined,
+    loyalty: undefined,
+    image_uris: { normal: 'https://img.scryfall.com/card.png' },
+    card_faces: [
+      {
+        name: 'Avatar Aang',
+        mana_cost: '{W}{U}',
+        type_line: 'Legendary Creature — Avatar',
+        oracle_text: 'Face one text.',
+        colors: ['W', 'U'],
+        power: '3',
+        toughness: '3'
+      },
+      {
+        name: 'Aang, Master of Elements',
+        mana_cost: '{W}{U}',
+        type_line: 'Legendary Creature — Avatar',
+        oracle_text: 'Face two text.',
+        colors: ['W', 'U'],
+        power: '4',
+        toughness: '4'
+      }
+    ]
+  };
+}
+
+describe('card tools', () => {
+  beforeEach(() => {
+    mockSearchCardByName.mockReset();
+    mockGetCardCollection.mockReset();
+    mockSearchCards.mockReset();
+    mockGetRandomCommander.mockReset();
+    mockGetCardRulings.mockReset();
+  });
+
+  it('returns card faces for search_card', async () => {
+    const mockCard = buildDoubleFacedCard();
+    mockSearchCardByName.mockResolvedValue(mockCard);
+    const tools = await loadTools();
+
+    const result = await invokeTool<{ cardName: string }, { success: boolean; card: ToolCard }>(
+      tools.searchCardTool,
+      { cardName: 'Avatar Aang' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.card.layout).toBe('transform');
+    expect(result.card.oracleText).toBeUndefined();
+    expect(result.card.colors).toBe('W, U');
+    expect(result.card.cardFaces).toHaveLength(2);
+    expect(result.card.cardFaces?.[0]?.name).toBe('Avatar Aang');
+    expect(result.card.cardFaces?.[0]?.oracleText).toBe('Face one text.');
+  });
+
+  it('returns card faces for card_collection', async () => {
+    const mockCard = buildDoubleFacedCard();
+    mockGetCardCollection.mockResolvedValue({ cards: [mockCard], notFound: [] });
+    const tools = await loadTools();
+
+    const result = await invokeTool<
+      { cardNames: string[] },
+      { success: boolean; count: number; cards: ToolCard[]; notFound: string[] }
+    >(tools.cardCollectionTool, { cardNames: ['Avatar Aang'] });
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(1);
+    expect(result.cards[0]?.cardFaces?.[1]?.name).toBe('Aang, Master of Elements');
+    expect(result.cards[0]?.cardFaces?.[1]?.oracleText).toBe('Face two text.');
+  });
+});

--- a/server/src/tools/card-tools.ts
+++ b/server/src/tools/card-tools.ts
@@ -1,6 +1,63 @@
 import { z } from 'zod';
 import { tool } from '@openai/agents';
 import { scryfallService } from '../services/scryfall';
+import type { Card, CardFace } from '../types/shared';
+
+type ToolCardFace = {
+  name?: string;
+  manaCost?: string;
+  type?: string;
+  oracleText?: string;
+  colors?: string;
+  power?: string;
+  toughness?: string;
+  loyalty?: string;
+};
+
+type ToolCard = {
+  name: string;
+  layout?: string;
+  manaCost?: string;
+  type: string;
+  oracleText?: string;
+  colors: string;
+  power?: string;
+  toughness?: string;
+  loyalty?: string;
+  cardFaces?: ToolCardFace[];
+};
+
+function formatColors(colors?: string[]) {
+  return colors && colors.length > 0 ? colors.join(', ') : 'Colorless';
+}
+
+function formatCardFace(face: CardFace): ToolCardFace {
+  return {
+    name: face.name,
+    manaCost: face.mana_cost,
+    type: face.type_line,
+    oracleText: face.oracle_text,
+    colors: formatColors(face.colors),
+    power: face.power,
+    toughness: face.toughness,
+    loyalty: face.loyalty
+  };
+}
+
+function formatToolCard(card: Card): ToolCard {
+  return {
+    name: card.name,
+    layout: card.layout,
+    manaCost: card.mana_cost,
+    type: card.type_line,
+    oracleText: card.oracle_text,
+    colors: formatColors(card.color_identity),
+    power: card.power,
+    toughness: card.toughness,
+    loyalty: card.loyalty,
+    cardFaces: card.card_faces?.map(formatCardFace)
+  };
+}
 
 /**
  * Card Search Tool
@@ -30,15 +87,7 @@ export const searchCardTool = tool({
 
     return {
       success: true,
-      card: {
-        name: card.name,
-        manaCost: card.mana_cost,
-        type: card.type_line,
-        oracleText: card.oracle_text,
-        colors: card.color_identity.join(', ') || 'Colorless',
-        power: card.power,
-        toughness: card.toughness
-      }
+      card: formatToolCard(card)
     };
   }
 });
@@ -64,15 +113,7 @@ export const cardCollectionTool = tool({
       success: true,
       count: cards.length,
       notFound,
-      cards: cards.map(card => ({
-        name: card.name,
-        manaCost: card.mana_cost,
-        type: card.type_line,
-        oracleText: card.oracle_text,
-        colors: card.color_identity.join(', ') || 'Colorless',
-        power: card.power,
-        toughness: card.toughness
-      }))
+      cards: cards.map((card) => formatToolCard(card))
     };
   }
 });
@@ -117,12 +158,7 @@ export const advancedSearchTool = tool({
     return {
       success: true,
       count: cards.length,
-      cards: cards.map(card => ({
-        name: card.name,
-        manaCost: card.mana_cost,
-        type: card.type_line,
-        colors: card.color_identity.join(', ') || 'Colorless'
-      }))
+      cards: cards.map((card) => formatToolCard(card))
     };
   }
 });
@@ -186,15 +222,7 @@ export const randomCommanderTool = tool({
 
     return {
       success: true,
-      commander: {
-        name: commander.name,
-        manaCost: commander.mana_cost,
-        type: commander.type_line,
-        colors: commander.color_identity.join(', ') || 'Colorless',
-        oracleText: commander.oracle_text,
-        power: commander.power,
-        toughness: commander.toughness
-      }
+      commander: formatToolCard(commander)
     };
   }
 });

--- a/server/src/types/shared.ts
+++ b/server/src/types/shared.ts
@@ -4,11 +4,30 @@
 export interface Card {
   id: string;
   name: string;
+  layout?: string;
   mana_cost?: string;
   type_line: string;
   oracle_text?: string;
   colors?: string[];
   color_identity: string[];
+  power?: string;
+  toughness?: string;
+  loyalty?: string;
+  image_uris?: {
+    normal?: string;
+    large?: string;
+    small?: string;
+    art_crop?: string;
+  };
+  card_faces?: CardFace[];
+}
+
+export interface CardFace {
+  name?: string;
+  mana_cost?: string;
+  type_line?: string;
+  oracle_text?: string;
+  colors?: string[];
   power?: string;
   toughness?: string;
   loyalty?: string;


### PR DESCRIPTION
## Summary\n- include layout and card face data in Scryfall card responses\n- expose card face fields in card tools for search, collection, advanced search, and random commander\n- add tests for double-faced card output\n\n## Testing\n- npm test\n- npm run build\n\nCloses #11