### PR TITLE
Tighten CD permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,6 +36,8 @@ jobs:
           REPO: ${{ vars.GCP_ARTIFACT_REPO || 'before-that-resolves' }}
           IMAGE_NAME: ${{ vars.GCP_IMAGE_NAME || 'before-that-resolves' }}
           ENABLE_PDF: ${{ vars.ENABLE_PDF || '1' }}
+          SKIP_SERVICE_ENABLE: '1'
+          SKIP_ARTIFACT_REPO_CREATE: '1'
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           CLOUD_SQL_INSTANCE: ${{ secrets.CLOUD_SQL_INSTANCE }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -100,6 +100,8 @@ Common options (environment variables):
 - `REPO` (default: `before-that-resolves`)
 - `IMAGE_NAME` (default: `before-that-resolves`)
 - `ENABLE_PDF` (default: `1`)
+- `SKIP_SERVICE_ENABLE` (default: `0`, set to `1` to skip enabling APIs)
+- `SKIP_ARTIFACT_REPO_CREATE` (default: `0`, set to `1` to skip repository creation)
 - `VITE_GOOGLE_CLIENT_ID` (Google login client ID baked into the build)
 - `GOOGLE_CLIENT_ID` (required for Google login / deck collections)
 - `CLOUD_SQL_INSTANCE` (e.g. `before-that-resolves:us-central1:btr-postgres`)
@@ -171,3 +173,5 @@ gh variable set DB_SSL -b "false"
 ```
 
 After this, merges to `main` will trigger a Cloud Build + Cloud Run deploy using the same script as local deploys (`deploy/cloudrun-deploy.sh`).
+
+The CD workflow sets `SKIP_SERVICE_ENABLE=1` and `SKIP_ARTIFACT_REPO_CREATE=1` to avoid requiring elevated permissions at deploy time.

--- a/deploy/cloudrun-deploy.sh
+++ b/deploy/cloudrun-deploy.sh
@@ -7,6 +7,8 @@ SERVICE_NAME=${SERVICE_NAME:-before-that-resolves}
 REPO=${REPO:-before-that-resolves}
 IMAGE_NAME=${IMAGE_NAME:-before-that-resolves}
 ENABLE_PDF=${ENABLE_PDF:-1}
+SKIP_SERVICE_ENABLE=${SKIP_SERVICE_ENABLE:-0}
+SKIP_ARTIFACT_REPO_CREATE=${SKIP_ARTIFACT_REPO_CREATE:-0}
 VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID:-}
 GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
 CLOUD_SQL_INSTANCE=${CLOUD_SQL_INSTANCE:-}
@@ -21,15 +23,19 @@ printf 'Using project %s in %s\n' "$PROJECT_ID" "$REGION"
 
 gcloud config set project "$PROJECT_ID" > /dev/null
 
-gcloud services enable \
-  run.googleapis.com \
-  cloudbuild.googleapis.com \
-  artifactregistry.googleapis.com
+if [[ "$SKIP_SERVICE_ENABLE" != "1" ]]; then
+  gcloud services enable \
+    run.googleapis.com \
+    cloudbuild.googleapis.com \
+    artifactregistry.googleapis.com
+fi
 
-if ! gcloud artifacts repositories describe "$REPO" --location "$REGION" > /dev/null 2>&1; then
-  gcloud artifacts repositories create "$REPO" \
-    --location "$REGION" \
-    --repository-format docker
+if [[ "$SKIP_ARTIFACT_REPO_CREATE" != "1" ]]; then
+  if ! gcloud artifacts repositories describe "$REPO" --location "$REGION" > /dev/null 2>&1; then
+    gcloud artifacts repositories create "$REPO" \
+      --location "$REGION" \
+      --repository-format docker
+  fi
 fi
 
 gcloud builds submit \


### PR DESCRIPTION
Skips service enable/repo creation in CD and documents the new envs so the deploy service account can use least-privilege roles.