### PR TITLE
Fix game logs date display showing one day earlier

### DIFF
--- a/client/src/components/GameLogs.tsx
+++ b/client/src/components/GameLogs.tsx
@@ -8,7 +8,8 @@ type GameLogsProps = {
 };
 
 function formatDate(value: string): string {
-  const parsed = new Date(value);
+  // Append time to treat date-only strings as local time, not UTC
+  const parsed = new Date(value.includes('T') ? value : `${value}T00:00:00`);
   if (Number.isNaN(parsed.valueOf())) {
     return value;
   }


### PR DESCRIPTION
## Summary
- Fix timezone bug where game log dates were displayed one day earlier than expected
- Date-only strings (e.g., "2025-01-10") were parsed as UTC midnight, causing display issues in local timezones

## Root Cause
JavaScript's `new Date("2025-01-10")` interprets date-only strings as UTC midnight. When displayed with `toLocaleDateString()` in timezones behind UTC (like US timezones), this shows as the previous day.

## Fix
Append `T00:00:00` to date-only strings to treat them as local midnight instead of UTC midnight.

## Test plan
- [x] Tests pass
- [x] Build succeeds
- [ ] Verify date displays correctly in game logs list view

Fixes #36

Generated with [Claude Code](https://claude.com/claude-code)