### PR TITLE
Allow commander Scryfall links

### DIFF
--- a/client/src/components/DeckCollection.test.tsx
+++ b/client/src/components/DeckCollection.test.tsx
@@ -9,6 +9,7 @@ const baseDeck = (overrides: Partial<DeckEntry> = {}): DeckEntry => ({
   name: 'Alpha',
   url: null,
   commanderNames: [],
+  commanderLinks: [],
   colorIdentity: null,
   source: 'manual',
   addedAt: '2025-01-01T00:00:00.000Z',
@@ -140,6 +141,32 @@ describe('DeckCollection', () => {
     });
   });
 
+  it('allows adding a second commander name', async () => {
+    const user = userEvent.setup();
+    const onCreateDeck = vi.fn().mockResolvedValue(true);
+
+    render(<DeckCollection {...defaultProps} onCreateDeck={onCreateDeck} />);
+
+    await user.click(screen.getByRole('button', { name: /\+\s*Deck/ }));
+    await user.type(screen.getByLabelText('Deck name (required)'), 'Two Commanders');
+
+    await user.click(screen.getByRole('button', { name: '+ Commander' }));
+
+    const commanderInputs = screen.getAllByLabelText('Commander name');
+    expect(commanderInputs).toHaveLength(2);
+
+    await user.type(commanderInputs[0], 'Tymna the Weaver');
+    await user.type(commanderInputs[1], 'Kraum');
+
+    await user.click(screen.getByRole('button', { name: 'Add Deck' }));
+
+    await waitFor(() => {
+      expect(onCreateDeck).toHaveBeenCalledWith(
+        expect.objectContaining({ commanderNames: ['Tymna the Weaver', 'Kraum'] })
+      );
+    });
+  });
+
   it('loads deck details from an Archidekt link', async () => {
     const user = userEvent.setup();
     const onPreviewDeck = vi.fn().mockResolvedValue({
@@ -175,7 +202,7 @@ describe('DeckCollection', () => {
     });
 
     expect(screen.getByLabelText('Deck name (required)')).toHaveValue('Archidekt Preview');
-    expect(screen.getByLabelText('Commander name(s) (optional)')).toHaveValue('Giada, Font of Hope');
+    expect(screen.getByLabelText('Commander(s) (optional)')).toHaveValue('Giada, Font of Hope');
   });
 
   it('opens edit modal and saves updates', async () => {

--- a/client/src/hooks/useDeckCollection.test.tsx
+++ b/client/src/hooks/useDeckCollection.test.tsx
@@ -35,6 +35,11 @@ function HookHarness() {
   );
 }
 
+const mockJsonResponse = (payload: unknown, ok: boolean = true) => ({
+  ok,
+  text: async () => JSON.stringify(payload)
+});
+
 describe('useDeckCollection', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let credentialCallback: ((response: { credential?: string }) => void) | null = null;
@@ -72,10 +77,7 @@ describe('useDeckCollection', () => {
 
   it('restores a stored token and loads decks', async () => {
     window.localStorage.setItem(TOKEN_STORAGE_KEY, 'token-123');
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true, user: { id: 'user-1' }, decks: [] })
-    });
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ success: true, user: { id: 'user-1' }, decks: [] }));
 
     render(<HookHarness />);
 
@@ -93,10 +95,7 @@ describe('useDeckCollection', () => {
   });
 
   it('persists token after Google login callback', async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true, user: { id: 'user-2' }, decks: [] })
-    });
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ success: true, user: { id: 'user-2' }, decks: [] }));
 
     render(<HookHarness />);
 
@@ -123,10 +122,7 @@ describe('useDeckCollection', () => {
 
   it('clears a stored token if loading decks fails', async () => {
     window.localStorage.setItem(TOKEN_STORAGE_KEY, 'token-bad');
-    fetchMock.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ success: false, error: 'Invalid token' })
-    });
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ success: false, error: 'Invalid token' }, false));
 
     render(<HookHarness />);
 
@@ -140,10 +136,7 @@ describe('useDeckCollection', () => {
   it('clears token on sign out', async () => {
     const user = userEvent.setup();
     window.localStorage.setItem(TOKEN_STORAGE_KEY, 'token-321');
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true, user: { id: 'user-3' }, decks: [] })
-    });
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ success: true, user: { id: 'user-3' }, decks: [] }));
 
     render(<HookHarness />);
 

--- a/server/src/services/deck-collection.integration.test.ts
+++ b/server/src/services/deck-collection.integration.test.ts
@@ -31,6 +31,7 @@ integration('deck collection persistence (integration)', () => {
       url: 'https://archidekt.com/decks/1/test',
       format: 'commander',
       commanderNames: ['Commander One'],
+      commanderLinks: [],
       colorIdentity: ['G'],
       source: 'archidekt'
     });
@@ -41,6 +42,7 @@ integration('deck collection persistence (integration)', () => {
       url: null,
       format: null,
       commanderNames: [],
+      commanderLinks: [],
       colorIdentity: null,
       source: 'manual'
     });

--- a/server/src/services/scryfall.ts
+++ b/server/src/services/scryfall.ts
@@ -196,6 +196,7 @@ export class ScryfallService {
     return {
       id: scryfallCard.id,
       name: scryfallCard.name,
+      scryfall_uri: scryfallCard.scryfall_uri,
       layout: scryfallCard.layout,
       mana_cost: scryfallCard.mana_cost,
       type_line: scryfallCard.type_line,
@@ -214,6 +215,7 @@ export class ScryfallService {
 type ScryfallCard = {
   id: string;
   name: string;
+  scryfall_uri?: string;
   layout?: string;
   mana_cost?: string;
   type_line: string;

--- a/server/src/types/shared.ts
+++ b/server/src/types/shared.ts
@@ -4,6 +4,7 @@
 export interface Card {
   id: string;
   name: string;
+  scryfall_uri?: string;
   layout?: string;
   mana_cost?: string;
   type_line: string;


### PR DESCRIPTION
## Summary\n- store commander names + Scryfall links for manual and Archidekt decks\n- add in-app Scryfall lookup for commander inputs with link preview\n- surface commander links in deck list with hover image\n- add scryfall lookup endpoint and safer JSON parsing\n\n## Testing\n- npm test\n- npm run build\n- npm run lint\n\nFixes #44