### PR TITLE
Fix mobile deck stats display

### DIFF
--- a/client/src/components/DeckCollection.test.tsx
+++ b/client/src/components/DeckCollection.test.tsx
@@ -114,6 +114,21 @@ describe('DeckCollection', () => {
     expect(deckNames[0]).toBe('High Stats');
   });
 
+  it('falls back to wins/losses when total games is zero', () => {
+    const decks = [
+      baseDeck({
+        id: 'deck-1',
+        name: 'Fallback Stats',
+        stats: { totalGames: 0, wins: 2, losses: 1, winRate: 0.66, lastPlayed: '2024-02-20' }
+      })
+    ];
+
+    render(<DeckCollection {...defaultProps} decks={decks} />);
+
+    const gamesLabel = screen.getByText('Games');
+    expect(gamesLabel.parentElement).toHaveTextContent('Games 3');
+  });
+
   it('opens the deck modal and validates required fields', async () => {
     const user = userEvent.setup();
     const onCreateDeck = vi.fn().mockResolvedValue(true);

--- a/client/src/components/DeckCollection.tsx
+++ b/client/src/components/DeckCollection.tsx
@@ -227,8 +227,16 @@ export function DeckCollection({
     localStorage.setItem(sortStorageKey, JSON.stringify({ key: sortKey, dir: sortDir }));
   }, [sortKey, sortDir]);
 
-  const getTotalGames = (deck: DeckEntry) =>
-    deck.stats?.totalGames ?? (deck.stats ? deck.stats.wins + deck.stats.losses : 0);
+  const getTotalGames = (deck: DeckEntry) => {
+    const stats = deck.stats;
+    if (!stats) return 0;
+    const total = Number(stats.totalGames);
+    if (Number.isFinite(total) && total > 0) {
+      return total;
+    }
+    const fallback = stats.wins + stats.losses;
+    return Number.isFinite(fallback) ? fallback : 0;
+  };
 
   const sortedDecks = useMemo(() => {
     const sorted = [...decks];


### PR DESCRIPTION
## Summary
- compute total games from wins/losses when totalGames is missing
- use the computed total for sorting and display to avoid mobile showing 0

## Testing
- npm test
- npm run build
- npm run lint