### PR TITLE
Add bulk deck import for Archidekt and Moxfield

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -317,7 +317,9 @@ function App() {
                     onCreateDeck={deckCollection.createDeck}
                     onUpdateDeck={deckCollection.updateDeck}
                     onPreviewDeck={deckCollection.previewDeck}
+                    onPreviewBulkDecks={deckCollection.previewBulkDecks}
                     onRemoveDeck={deckCollection.removeDeck}
+                    onBulkImportDecks={deckCollection.importBulkDecks}
                     onOpenInOracle={(deckUrl) => {
                       setPendingDeckUrl(deckUrl);
                       setView('oracle');


### PR DESCRIPTION
## Summary
- add bulk import endpoints to preview profile decks and import selections
- add bulk import modal + selection flow in deck collection UI
- add coverage for bulk import paths in server and client tests

## Checklist
- [ ] update docs if needed
- [ ] manual QA for bulk import flow
