### PR TITLE
Add session cookie auth with re-login UX

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -53,7 +53,11 @@ function App() {
   const [navOpen, setNavOpen] = useState(false);
   const [pendingDeckUrl, setPendingDeckUrl] = useState<string | undefined>(undefined);
   const deckCollection = useDeckCollection();
-  const sharedLogsState = useSharedGameLogs(deckCollection.idToken);
+  const authStatus = deckCollection.sessionStatus;
+  const sharedLogsState = useSharedGameLogs({
+    authStatus,
+    onAuthExpired: deckCollection.markAuthExpired
+  });
   const mainRef = useRef<HTMLElement | null>(null);
   const supportsReasoning = models.find((model) => model.id === selectedModel)?.reasoning ?? false;
   const supportsVerbosity = models.find((model) => model.id === selectedModel)?.verbosity ?? false;
@@ -135,8 +139,7 @@ function App() {
     }
   ];
   const decksEnabled = Boolean(deckCollection.googleClientId);
-  const profileLabel =
-    deckCollection.user?.name || deckCollection.user?.email || 'Profile';
+  const profileLabel = deckCollection.user?.name || deckCollection.user?.email || 'Profile';
   const profileInitials = getInitials(deckCollection.user?.name || deckCollection.user?.email);
   const handleNavSelect = (nextView: AppView) => {
     setView(nextView);
@@ -310,7 +313,10 @@ function App() {
                 <div className="flex-1 min-h-0 overflow-hidden">
                   <DeckCollection
                     enabled={decksEnabled}
-                    idToken={deckCollection.idToken}
+                    authStatus={authStatus}
+                    authError={deckCollection.authError}
+                    authButtonRef={deckCollection.buttonRef}
+                    onAuthExpired={deckCollection.markAuthExpired}
                     decks={deckCollection.decks}
                     loading={deckCollection.loading}
                     deckError={deckCollection.deckError}
@@ -332,7 +338,9 @@ function App() {
               {view === 'logs' && (
                 <GameLogs
                   enabled={decksEnabled}
-                  idToken={deckCollection.idToken}
+                  authStatus={authStatus}
+                  authButtonRef={deckCollection.buttonRef}
+                  onAuthExpired={deckCollection.markAuthExpired}
                   decks={deckCollection.decks}
                   decksLoading={deckCollection.loading}
                   sharedLogs={sharedLogsState.sharedLogs}
@@ -354,7 +362,7 @@ function App() {
                   </div>
                   <DeckAuthPanel
                     enabled={decksEnabled}
-                    idToken={deckCollection.idToken}
+                    authStatus={authStatus}
                     user={deckCollection.user}
                     authError={deckCollection.authError}
                     loading={deckCollection.loading}

--- a/client/src/components/DeckAuthPanel.tsx
+++ b/client/src/components/DeckAuthPanel.tsx
@@ -1,4 +1,5 @@
 import type { RefCallback } from 'react';
+import type { AuthStatus } from '../types/auth';
 
 type GoogleUser = {
   id: string;
@@ -9,7 +10,7 @@ type GoogleUser = {
 
 type DeckAuthPanelProps = {
   enabled: boolean;
-  idToken: string | null;
+  authStatus: AuthStatus;
   user: GoogleUser | null;
   authError: string | null;
   loading: boolean;
@@ -19,18 +20,20 @@ type DeckAuthPanelProps = {
 
 export function DeckAuthPanel({
   enabled,
-  idToken,
+  authStatus,
   user,
   authError,
   loading,
   buttonRef,
   onSignOut
 }: DeckAuthPanelProps) {
+  const isAuthenticated = authStatus === 'authenticated';
+  const authExpired = authStatus === 'expired';
   return (
     <div className="rounded-2xl border border-gray-800 bg-gray-900/70 p-4 text-sm text-gray-200">
       <div className="flex items-center justify-between mb-3">
         <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">Account</span>
-        {idToken && (
+        {isAuthenticated && (
           <button
             type="button"
             onClick={onSignOut}
@@ -47,15 +50,19 @@ export function DeckAuthPanel({
         </p>
       )}
 
-      {enabled && !idToken && (
+      {enabled && !isAuthenticated && authStatus !== 'unknown' && (
         <div className="flex flex-col gap-3">
-          <p className="text-gray-200">Sign in to save decks to your collection.</p>
+          <p className="text-gray-200">
+            {authExpired
+              ? 'Session expired. Sign in again to continue saving decks.'
+              : 'Sign in to save decks to your collection.'}
+          </p>
           <div ref={buttonRef} />
           {authError && <p className="text-red-400 text-xs">{authError}</p>}
         </div>
       )}
 
-      {enabled && idToken && (
+      {enabled && isAuthenticated && (
         <div className="flex items-center gap-3">
           {user?.picture && (
             <img
@@ -70,6 +77,9 @@ export function DeckAuthPanel({
             {loading && <p className="text-xs text-gray-400">Syncing decks...</p>}
           </div>
         </div>
+      )}
+      {enabled && authStatus === 'unknown' && (
+        <p className="text-gray-300">Checking session...</p>
       )}
     </div>
   );

--- a/client/src/components/DeckCollection.test.tsx
+++ b/client/src/components/DeckCollection.test.tsx
@@ -19,7 +19,10 @@ const baseDeck = (overrides: Partial<DeckEntry> = {}): DeckEntry => ({
 
 const defaultProps = {
   enabled: true,
-  idToken: 'token-123',
+  authStatus: 'authenticated' as const,
+  authError: null,
+  authButtonRef: vi.fn(),
+  onAuthExpired: vi.fn(),
   decks: [] as DeckEntry[],
   loading: false,
   deckError: null,

--- a/client/src/components/GameLogs.test.tsx
+++ b/client/src/components/GameLogs.test.tsx
@@ -9,15 +9,15 @@ const mockUseOpponentUsers = vi.fn();
 const mockUseOpponentDecks = vi.fn();
 
 vi.mock('../hooks/useGameLogs', () => ({
-  useGameLogs: (idToken: string | null) => mockUseGameLogs(idToken)
+  useGameLogs: (auth: { authStatus: string }) => mockUseGameLogs(auth)
 }));
 
 vi.mock('../hooks/useOpponentUsers', () => ({
-  useOpponentUsers: (idToken: string | null) => mockUseOpponentUsers(idToken)
+  useOpponentUsers: (auth: { authStatus: string }) => mockUseOpponentUsers(auth)
 }));
 
 vi.mock('../hooks/useOpponentDecks', () => ({
-  useOpponentDecks: (idToken: string | null) => mockUseOpponentDecks(idToken)
+  useOpponentDecks: (auth: { authStatus: string }) => mockUseOpponentDecks(auth)
 }));
 
 const baseLog = (overrides: Partial<GameLogEntry> = {}): GameLogEntry => ({
@@ -39,7 +39,9 @@ const renderGameLogs = (overrides: Partial<Parameters<typeof GameLogs>[0]> = {})
   return render(
     <GameLogs
       enabled
-      idToken="token-123"
+      authStatus="authenticated"
+      authButtonRef={vi.fn()}
+      onAuthExpired={vi.fn()}
       decks={[]}
       decksLoading={false}
       sharedLogs={[]}

--- a/client/src/hooks/useOpponentDecks.ts
+++ b/client/src/hooks/useOpponentDecks.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { buildApiUrl } from '../utils/api';
+import type { AuthStatus } from '../types/auth';
 
 export type OpponentDeck = {
   id: string;
@@ -16,35 +17,53 @@ type OpponentDecksResponse = {
   error?: string;
 };
 
-const readPayload = async <T extends { success?: boolean; error?: string }>(
-  response: Response
-): Promise<T> => {
-  const text = await response.text();
-  try {
-    return JSON.parse(text) as T;
-  } catch {
-    throw new Error('Unexpected response from server.');
-  }
+type AuthState = {
+  authStatus: AuthStatus;
+  onAuthExpired?: (message?: string) => void;
 };
 
-export function useOpponentDecks(idToken: string | null) {
+export function useOpponentDecks(auth: AuthState) {
+  const { authStatus, onAuthExpired } = auth;
+  const isAuthenticated = authStatus === 'authenticated';
   const [decksByUserId, setDecksByUserId] = useState<Record<string, OpponentDeck[]>>({});
   const [loadingByUserId, setLoadingByUserId] = useState<Record<string, boolean>>({});
   const [errorByUserId, setErrorByUserId] = useState<Record<string, string | null>>({});
   const decksRef = useRef(decksByUserId);
   decksRef.current = decksByUserId;
 
-  const headers = useMemo(() => {
-    if (!idToken) return null;
-    return {
-      Authorization: `Bearer ${idToken}`,
-      'Content-Type': 'application/json'
-    };
-  }, [idToken]);
+  const jsonHeaders = useMemo(() => ({
+    'Content-Type': 'application/json'
+  }), []);
+
+  const readPayload = useCallback(async <T extends { success?: boolean; error?: string; code?: string }>(
+    response: Response
+  ): Promise<T> => {
+    const text = await response.text();
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error('Unexpected response from server.');
+    }
+  }, []);
+
+  const handleAuthFailure = useCallback((
+    payload: { error?: string; code?: string },
+    response: Response,
+    fallbackMessage: string,
+    setMessage: (message: string) => void
+  ): boolean => {
+    if (response.status !== 401) return false;
+    const message = payload.error || fallbackMessage;
+    if (payload.code === 'auth_expired') {
+      onAuthExpired?.(message);
+    }
+    setMessage(message);
+    return true;
+  }, [onAuthExpired]);
 
   const loadOpponentDecks = useCallback(
     async (userId: string, options?: { force?: boolean }): Promise<OpponentDeck[]> => {
-      if (!headers) return [];
+      if (!isAuthenticated) return [];
       const trimmed = userId.trim();
       if (!trimmed) return [];
       if (!options?.force && decksRef.current[trimmed]) {
@@ -53,8 +72,16 @@ export function useOpponentDecks(idToken: string | null) {
       setLoadingByUserId((current) => ({ ...current, [trimmed]: true }));
       setErrorByUserId((current) => ({ ...current, [trimmed]: null }));
       try {
-        const response = await fetch(buildApiUrl(`/api/opponents/${encodeURIComponent(trimmed)}/decks`), { headers });
+        const response = await fetch(buildApiUrl(`/api/opponents/${encodeURIComponent(trimmed)}/decks`), {
+          headers: jsonHeaders,
+          credentials: 'include'
+        });
         const payload = await readPayload<OpponentDecksResponse>(response);
+        if (handleAuthFailure(payload, response, 'Unable to load opponent decks.', (message) => {
+          setErrorByUserId((current) => ({ ...current, [trimmed]: message }));
+        })) {
+          return [];
+        }
         if (!response.ok || !payload.success) {
           throw new Error(payload.error || 'Unable to load opponent decks.');
         }
@@ -69,7 +96,7 @@ export function useOpponentDecks(idToken: string | null) {
         setLoadingByUserId((current) => ({ ...current, [trimmed]: false }));
       }
     },
-    [headers]
+    [handleAuthFailure, isAuthenticated, jsonHeaders, readPayload]
   );
 
   return {

--- a/client/src/hooks/useSharedGameLogs.ts
+++ b/client/src/hooks/useSharedGameLogs.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { buildApiUrl } from '../utils/api';
 import type { GameLogOpponent } from './useGameLogs';
+import type { AuthStatus } from '../types/auth';
 
 export type SharedGameLogEntry = {
   id: string;
@@ -49,33 +50,68 @@ type SharedLogsResponse = {
   error?: string;
 };
 
+type AuthState = {
+  authStatus: AuthStatus;
+  onAuthExpired?: (message?: string) => void;
+};
+
 export function useSharedGameLogs(
-  idToken: string | null,
+  auth: AuthState,
   options: { autoLoad?: boolean } = {}
 ) {
+  const { authStatus, onAuthExpired } = auth;
+  const isAuthenticated = authStatus === 'authenticated';
   const [sharedLogs, setSharedLogs] = useState<SharedGameLogEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
-  const headers = useMemo(() => {
-    if (!idToken) return null;
-    return {
-      Authorization: `Bearer ${idToken}`,
-      'Content-Type': 'application/json'
-    };
-  }, [idToken]);
+  const jsonHeaders = useMemo(() => ({
+    'Content-Type': 'application/json'
+  }), []);
+
+  const readPayload = useCallback(async <T extends { success?: boolean; error?: string; code?: string }>(
+    response: Response
+  ): Promise<T> => {
+    const text = await response.text();
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error('Unexpected response from server.');
+    }
+  }, []);
+
+  const handleAuthFailure = useCallback((
+    payload: { error?: string; code?: string },
+    response: Response,
+    fallbackMessage: string
+  ): boolean => {
+    if (response.status !== 401) return false;
+    const message = payload.error || fallbackMessage;
+    if (payload.code === 'auth_expired') {
+      onAuthExpired?.(message);
+    }
+    setError(message);
+    return true;
+  }, [onAuthExpired]);
 
   const loadSharedLogs = useCallback(async () => {
-    if (!headers) {
+    if (authStatus === 'unauthenticated') {
       setSharedLogs([]);
       return;
     }
+    if (!isAuthenticated) return;
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch(buildApiUrl('/api/game-logs/shared'), { headers });
-      const payload = (await response.json()) as SharedLogsResponse;
+      const response = await fetch(buildApiUrl('/api/game-logs/shared'), {
+        headers: jsonHeaders,
+        credentials: 'include'
+      });
+      const payload = await readPayload<SharedLogsResponse>(response);
+      if (handleAuthFailure(payload, response, 'Unable to load shared game logs.')) {
+        return;
+      }
       if (!response.ok || !payload.success) {
         throw new Error(payload.error || 'Unable to load shared game logs.');
       }
@@ -86,21 +122,22 @@ export function useSharedGameLogs(
     } finally {
       setLoading(false);
     }
-  }, [headers]);
+  }, [authStatus, handleAuthFailure, isAuthenticated, jsonHeaders, readPayload]);
 
   useEffect(() => {
-    if (!headers) {
+    if (authStatus === 'unauthenticated') {
       setSharedLogs([]);
       return;
     }
+    if (!isAuthenticated) return;
     if (options.autoLoad === false) {
       return;
     }
     void loadSharedLogs();
-  }, [headers, loadSharedLogs, options.autoLoad]);
+  }, [authStatus, isAuthenticated, loadSharedLogs, options.autoLoad]);
 
   const updateSharedLog = useCallback(async (logId: string, input: SharedGameLogUpdate): Promise<boolean> => {
-    if (!headers) {
+    if (!isAuthenticated) {
       setError('Sign in with Google to edit shared logs.');
       return false;
     }
@@ -110,10 +147,14 @@ export function useSharedGameLogs(
     try {
       const response = await fetch(buildApiUrl(`/api/game-logs/shared/${logId}`), {
         method: 'PATCH',
-        headers,
+        headers: jsonHeaders,
+        credentials: 'include',
         body: JSON.stringify(input)
       });
-      const payload = (await response.json()) as SharedLogsResponse;
+      const payload = await readPayload<SharedLogsResponse>(response);
+      if (handleAuthFailure(payload, response, 'Unable to update shared game log.')) {
+        return false;
+      }
       if (!response.ok || !payload.success) {
         throw new Error(payload.error || 'Unable to update shared game log.');
       }
@@ -127,10 +168,10 @@ export function useSharedGameLogs(
     } finally {
       setLoading(false);
     }
-  }, [headers]);
+  }, [handleAuthFailure, isAuthenticated, jsonHeaders, readPayload]);
 
   const acceptSharedLog = useCallback(async (logId: string): Promise<boolean> => {
-    if (!headers) {
+    if (!isAuthenticated) {
       setError('Sign in with Google to accept shared logs.');
       return false;
     }
@@ -140,9 +181,13 @@ export function useSharedGameLogs(
     try {
       const response = await fetch(buildApiUrl(`/api/game-logs/shared/${logId}/accept`), {
         method: 'POST',
-        headers
+        headers: jsonHeaders,
+        credentials: 'include'
       });
-      const payload = (await response.json()) as SharedLogsResponse;
+      const payload = await readPayload<SharedLogsResponse>(response);
+      if (handleAuthFailure(payload, response, 'Unable to accept shared game log.')) {
+        return false;
+      }
       if (!response.ok || !payload.success) {
         throw new Error(payload.error || 'Unable to accept shared game log.');
       }
@@ -156,10 +201,10 @@ export function useSharedGameLogs(
     } finally {
       setLoading(false);
     }
-  }, [headers]);
+  }, [handleAuthFailure, isAuthenticated, jsonHeaders, readPayload]);
 
   const rejectSharedLog = useCallback(async (logId: string): Promise<boolean> => {
-    if (!headers) {
+    if (!isAuthenticated) {
       setError('Sign in with Google to reject shared logs.');
       return false;
     }
@@ -169,9 +214,13 @@ export function useSharedGameLogs(
     try {
       const response = await fetch(buildApiUrl(`/api/game-logs/shared/${logId}/reject`), {
         method: 'POST',
-        headers
+        headers: jsonHeaders,
+        credentials: 'include'
       });
-      const payload = (await response.json()) as SharedLogsResponse;
+      const payload = await readPayload<SharedLogsResponse>(response);
+      if (handleAuthFailure(payload, response, 'Unable to reject shared game log.')) {
+        return false;
+      }
       if (!response.ok || !payload.success) {
         throw new Error(payload.error || 'Unable to reject shared game log.');
       }
@@ -185,7 +234,7 @@ export function useSharedGameLogs(
     } finally {
       setLoading(false);
     }
-  }, [headers]);
+  }, [handleAuthFailure, isAuthenticated, jsonHeaders, readPayload]);
 
   return {
     sharedLogs,

--- a/client/src/types/auth.ts
+++ b/client/src/types/auth.ts
@@ -1,0 +1,1 @@
+export type AuthStatus = 'unknown' | 'authenticated' | 'unauthenticated' | 'expired';

--- a/server/src/services/db.ts
+++ b/server/src/services/db.ts
@@ -11,6 +11,15 @@ const schemaQueries = [
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
   );`,
+  `CREATE TABLE IF NOT EXISTS user_sessions (
+    session_id_hash TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );`,
+  `CREATE INDEX IF NOT EXISTS user_sessions_user_idx ON user_sessions (user_id);`,
+  `CREATE INDEX IF NOT EXISTS user_sessions_expires_at_idx ON user_sessions (expires_at);`,
   `CREATE TABLE IF NOT EXISTS decks (
     user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     deck_id TEXT NOT NULL,

--- a/server/src/services/deck-collection.ts
+++ b/server/src/services/deck-collection.ts
@@ -65,6 +65,24 @@ export async function upsertUser(user: GoogleUser): Promise<void> {
   );
 }
 
+export async function getUserById(userId: string): Promise<GoogleUser | null> {
+  const db = getPool();
+  const result = await db.query<{ id: string; email: string | null; name: string | null; picture: string | null }>(
+    `SELECT id, email, name, picture FROM users WHERE id = $1`,
+    [userId]
+  );
+  if (result.rows.length === 0) {
+    return null;
+  }
+  const row = result.rows[0];
+  return {
+    id: row.id,
+    email: row.email ?? undefined,
+    name: row.name ?? undefined,
+    picture: row.picture ?? undefined
+  };
+}
+
 export async function listDeckCollection(userId: string): Promise<DeckCollectionEntry[]> {
   const db = getPool();
   const result = await db.query<DeckRow>(

--- a/server/src/services/session.ts
+++ b/server/src/services/session.ts
@@ -1,0 +1,78 @@
+import crypto from 'node:crypto';
+import { getPool } from './db';
+
+export const SESSION_TTL_MS = 8 * 24 * 60 * 60 * 1000;
+export const SESSION_COOKIE_NAME = 'btr_session';
+
+export type SessionRecord = {
+  userId: string;
+  expiresAt: Date;
+  lastSeenAt: Date;
+};
+
+const hashSessionId = (sessionId: string) =>
+  crypto.createHash('sha256').update(sessionId).digest('hex');
+
+export async function createSession(userId: string): Promise<{ sessionId: string; expiresAt: Date }> {
+  const db = getPool();
+  const sessionId = crypto.randomUUID();
+  const sessionIdHash = hashSessionId(sessionId);
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+  await db.query(
+    `INSERT INTO user_sessions (session_id_hash, user_id, expires_at, last_seen_at)
+     VALUES ($1, $2, $3, NOW())`,
+    [sessionIdHash, userId, expiresAt]
+  );
+  return { sessionId, expiresAt };
+}
+
+export async function getSession(sessionId: string): Promise<SessionRecord | null> {
+  const db = getPool();
+  const sessionIdHash = hashSessionId(sessionId);
+  const result = await db.query<{
+    user_id: string;
+    expires_at: Date;
+    last_seen_at: Date;
+  }>(
+    `SELECT user_id, expires_at, last_seen_at
+     FROM user_sessions
+     WHERE session_id_hash = $1`,
+    [sessionIdHash]
+  );
+  if (result.rows.length === 0) {
+    return null;
+  }
+  const row = result.rows[0];
+  return {
+    userId: row.user_id,
+    expiresAt: row.expires_at instanceof Date ? row.expires_at : new Date(row.expires_at),
+    lastSeenAt: row.last_seen_at instanceof Date ? row.last_seen_at : new Date(row.last_seen_at)
+  };
+}
+
+export async function touchSession(sessionId: string): Promise<Date | null> {
+  const db = getPool();
+  const sessionIdHash = hashSessionId(sessionId);
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+  const result = await db.query<{ expires_at: Date }>(
+    `UPDATE user_sessions
+     SET expires_at = $2, last_seen_at = NOW()
+     WHERE session_id_hash = $1
+     RETURNING expires_at`,
+    [sessionIdHash, expiresAt]
+  );
+  if (result.rows.length === 0) {
+    return null;
+  }
+  const updated = result.rows[0].expires_at;
+  return updated instanceof Date ? updated : new Date(updated);
+}
+
+export async function deleteSession(sessionId: string): Promise<void> {
+  const db = getPool();
+  const sessionIdHash = hashSessionId(sessionId);
+  await db.query(
+    `DELETE FROM user_sessions WHERE session_id_hash = $1`,
+    [sessionIdHash]
+  );
+}


### PR DESCRIPTION
## Summary\n- add session cookie storage with sliding 8-day expiry and auth endpoints\n- switch client data hooks to cookie auth and handle auth-expired state without losing edits\n- update tests for session auth flow\n\n## Testing\n- npm run build\n- npm test\n- npm run lint