### PR TITLE
Display progress towards 32 deck challenge

### DIFF
--- a/client/src/components/DeckCollection.test.tsx
+++ b/client/src/components/DeckCollection.test.tsx
@@ -53,7 +53,8 @@ describe('DeckCollection', () => {
     expect(screen.getByText('2 total')).toBeInTheDocument();
   });
 
-  it('shows 32 challenge progress and deck lines by color identity', () => {
+  it('shows 32 challenge in a modal and renders deck lines by color identity', async () => {
+    const user = userEvent.setup();
     const decks = [
       baseDeck({ id: 'deck-w-1', name: 'White One', commanderNames: ['Giada'], colorIdentity: ['W'] }),
       baseDeck({ id: 'deck-w-2', name: 'White Two', commanderNames: ['Adeline'], colorIdentity: ['W'] }),
@@ -64,7 +65,11 @@ describe('DeckCollection', () => {
 
     render(<DeckCollection {...defaultProps} decks={decks} />);
 
-    expect(screen.getByText('32 Deck Challenge')).toBeInTheDocument();
+    expect(screen.queryByText('3 of 32 colors completed')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '32 Challenge (3/32)' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '32 Challenge (3/32)' }));
+
     expect(screen.getByText('3 of 32 colors completed')).toBeInTheDocument();
     expect(screen.getByText('White One — Giada')).toBeInTheDocument();
     expect(screen.getByText('White Two — Adeline')).toBeInTheDocument();

--- a/client/src/components/DeckCollection.test.tsx
+++ b/client/src/components/DeckCollection.test.tsx
@@ -40,12 +40,36 @@ describe('DeckCollection', () => {
     localStorage.clear();
   });
 
+  const getDeckOrder = () =>
+    screen
+      .getAllByRole('button', { name: /^Edit / })
+      .map((button) => (button.getAttribute('aria-label') || '').replace(/^Edit /, ''));
+
   it('shows the deck count in the header', () => {
     const decks = [baseDeck({ id: 'deck-1' }), baseDeck({ id: 'deck-2', name: 'Beta' })];
 
     render(<DeckCollection {...defaultProps} decks={decks} />);
 
     expect(screen.getByText('2 total')).toBeInTheDocument();
+  });
+
+  it('shows 32 challenge progress and deck lines by color identity', () => {
+    const decks = [
+      baseDeck({ id: 'deck-w-1', name: 'White One', commanderNames: ['Giada'], colorIdentity: ['W'] }),
+      baseDeck({ id: 'deck-w-2', name: 'White Two', commanderNames: ['Adeline'], colorIdentity: ['W'] }),
+      baseDeck({ id: 'deck-ub', name: 'Dimir Deck', commanderNames: ['Yuriko'], colorIdentity: ['U', 'B'] }),
+      baseDeck({ id: 'deck-c', name: 'Colorless Deck', commanderNames: ['Kozilek'], colorIdentity: [] }),
+      baseDeck({ id: 'deck-unknown', name: 'Unknown Colors', commanderNames: ['Mystery'], colorIdentity: null })
+    ];
+
+    render(<DeckCollection {...defaultProps} decks={decks} />);
+
+    expect(screen.getByText('32 Deck Challenge')).toBeInTheDocument();
+    expect(screen.getByText('3 of 32 colors completed')).toBeInTheDocument();
+    expect(screen.getByText('White One — Giada')).toBeInTheDocument();
+    expect(screen.getByText('White Two — Adeline')).toBeInTheDocument();
+    expect(screen.getByText('Dimir Deck — Yuriko')).toBeInTheDocument();
+    expect(screen.getByText('Colorless Deck — Kozilek')).toBeInTheDocument();
   });
 
   it('renders sort controls and sorts cards', async () => {
@@ -60,17 +84,17 @@ describe('DeckCollection', () => {
     const sortSelect = screen.getByLabelText('Sort');
     expect(sortSelect).toBeInTheDocument();
 
-    let deckNames = screen.getAllByText(/Alpha|Beta/).map((node) => node.textContent);
+    let deckNames = getDeckOrder();
     expect(deckNames[0]).toBe('Alpha');
 
     await user.selectOptions(sortSelect, 'commander');
 
-    deckNames = screen.getAllByText(/Alpha|Beta/).map((node) => node.textContent);
+    deckNames = getDeckOrder();
     expect(deckNames[0]).toBe('Beta');
 
     await user.click(screen.getByRole('button', { name: /Sort descending/ }));
 
-    deckNames = screen.getAllByText(/Alpha|Beta/).map((node) => node.textContent);
+    deckNames = getDeckOrder();
     expect(deckNames[0]).toBe('Alpha');
   });
 
@@ -94,12 +118,12 @@ describe('DeckCollection', () => {
     const sortSelect = screen.getByLabelText('Sort');
     await user.selectOptions(sortSelect, 'games');
 
-    let deckNames = screen.getAllByText(/Low Stats|High Stats/).map((node) => node.textContent);
+    let deckNames = getDeckOrder();
     expect(deckNames[0]).toBe('High Stats');
 
     await user.selectOptions(sortSelect, 'lastPlayed');
 
-    deckNames = screen.getAllByText(/Low Stats|High Stats/).map((node) => node.textContent);
+    deckNames = getDeckOrder();
     expect(deckNames[0]).toBe('High Stats');
   });
 
@@ -123,7 +147,7 @@ describe('DeckCollection', () => {
     const sortSelect = screen.getByLabelText('Sort') as HTMLSelectElement;
     expect(sortSelect.value).toBe('games');
 
-    const deckNames = screen.getAllByText(/Low Stats|High Stats/).map((node) => node.textContent);
+    const deckNames = getDeckOrder();
     expect(deckNames[0]).toBe('High Stats');
   });
 

--- a/client/src/components/DeckCollection.test.tsx
+++ b/client/src/components/DeckCollection.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DeckCollection, type DeckEntry } from './DeckCollection';
 import { buildApiUrl } from '../utils/api';
@@ -56,7 +56,14 @@ describe('DeckCollection', () => {
   it('shows 32 challenge collapsed by default and expands with progress/details', async () => {
     const user = userEvent.setup();
     const decks = [
-      baseDeck({ id: 'deck-w-1', name: 'White One', commanderNames: ['Giada'], colorIdentity: ['W'] }),
+      baseDeck({
+        id: 'deck-w-1',
+        name: 'White One',
+        url: 'https://archidekt.com/decks/1',
+        commanderNames: ['Giada'],
+        commanderLinks: ['https://scryfall.com/card/one/giada'],
+        colorIdentity: ['W']
+      }),
       baseDeck({ id: 'deck-w-2', name: 'White Two', commanderNames: ['Adeline'], colorIdentity: ['W'] }),
       baseDeck({ id: 'deck-ub', name: 'Dimir Deck', commanderNames: ['Yuriko'], colorIdentity: ['U', 'B'] }),
       baseDeck({ id: 'deck-c', name: 'Colorless Deck', commanderNames: ['Kozilek'], colorIdentity: [] }),
@@ -71,11 +78,19 @@ describe('DeckCollection', () => {
 
     await user.click(screen.getByRole('button', { name: /32 Deck Challenge \(3\/32\)/ }));
 
+    const challengePanel = document.getElementById('challenge-panel-content');
+    expect(challengePanel).not.toBeNull();
+    const challenge = within(challengePanel as HTMLElement);
+
     expect(screen.getByText('3 of 32 colors completed')).toBeInTheDocument();
-    expect(screen.getByText('White One — Giada')).toBeInTheDocument();
-    expect(screen.getByText('White Two — Adeline')).toBeInTheDocument();
-    expect(screen.getByText('Dimir Deck — Yuriko')).toBeInTheDocument();
-    expect(screen.getByText('Colorless Deck — Kozilek')).toBeInTheDocument();
+    expect(challenge.getByText('White Two')).toBeInTheDocument();
+    expect(challenge.getByText('Adeline')).toBeInTheDocument();
+    expect(challenge.getByText('Dimir Deck')).toBeInTheDocument();
+    expect(challenge.getByText('Yuriko')).toBeInTheDocument();
+    expect(challenge.getByText('Colorless Deck')).toBeInTheDocument();
+    expect(challenge.getByText('Kozilek')).toBeInTheDocument();
+    expect(challenge.getByRole('link', { name: 'White One' })).toHaveAttribute('href', 'https://archidekt.com/decks/1');
+    expect(challenge.getByRole('link', { name: 'Giada' })).toHaveAttribute('href', 'https://scryfall.com/card/one/giada');
   });
 
   it('renders sort controls and sorts cards', async () => {

--- a/client/src/components/DeckCollection.test.tsx
+++ b/client/src/components/DeckCollection.test.tsx
@@ -53,7 +53,7 @@ describe('DeckCollection', () => {
     expect(screen.getByText('2 total')).toBeInTheDocument();
   });
 
-  it('shows 32 challenge in a modal and renders deck lines by color identity', async () => {
+  it('shows 32 challenge collapsed by default and expands with progress/details', async () => {
     const user = userEvent.setup();
     const decks = [
       baseDeck({ id: 'deck-w-1', name: 'White One', commanderNames: ['Giada'], colorIdentity: ['W'] }),
@@ -66,9 +66,10 @@ describe('DeckCollection', () => {
     render(<DeckCollection {...defaultProps} decks={decks} />);
 
     expect(screen.queryByText('3 of 32 colors completed')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '32 Challenge (3/32)' })).toBeInTheDocument();
+    expect(screen.queryByText('White One — Giada')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /32 Deck Challenge \(3\/32\)/ })).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: '32 Challenge (3/32)' }));
+    await user.click(screen.getByRole('button', { name: /32 Deck Challenge \(3\/32\)/ }));
 
     expect(screen.getByText('3 of 32 colors completed')).toBeInTheDocument();
     expect(screen.getByText('White One — Giada')).toBeInTheDocument();

--- a/client/src/components/DeckCollection.tsx
+++ b/client/src/components/DeckCollection.tsx
@@ -18,9 +18,6 @@ const PREDEFINED_TAGS = [
   'scooped'
 ] as const;
 
-const CHALLENGE_TEMPLATE_IMAGE_URL =
-  'https://github.com/user-attachments/assets/544b6796-ac23-47d8-8dc7-ea07ad10d00b';
-
 type ChallengeIdentity = {
   key: string;
   label: string;
@@ -359,7 +356,7 @@ export function DeckCollection({
   const [showScrollHint, setShowScrollHint] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>(() => initialSort?.key ?? 'name');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>(() => initialSort?.dir ?? 'asc');
-  const [challengeModalOpen, setChallengeModalOpen] = useState(false);
+  const [challengeCollapsed, setChallengeCollapsed] = useState(true);
   const [hoverCard, setHoverCard] = useState<{ label: string; rect: DOMRect } | null>(null);
   const popupRef = useRef<HTMLDivElement | null>(null);
   const anchorRef = useRef<HTMLAnchorElement | null>(null);
@@ -1508,15 +1505,54 @@ export function DeckCollection({
             >
               Bulk import
             </button>
-            <button
-              type="button"
-              onClick={() => setChallengeModalOpen(true)}
-              className="inline-flex items-center justify-center gap-2 rounded-full border border-emerald-400/60 px-5 py-2 text-sm font-semibold text-emerald-100 hover:border-emerald-300 hover:text-emerald-50"
-            >
-              32 Challenge ({challengeCompletedCount}/32)
-            </button>
           </div>
         </div>
+        <section className="mt-6 rounded-xl border border-gray-800 bg-gray-950/60">
+          <button
+            type="button"
+            onClick={() => setChallengeCollapsed((prev) => !prev)}
+            className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-gray-900/60"
+            aria-expanded={!challengeCollapsed}
+            aria-controls="challenge-panel-content"
+          >
+            <span className="text-sm font-semibold uppercase tracking-wide text-gray-200">
+              32 Deck Challenge ({challengeCompletedCount}/32)
+            </span>
+            <span className="text-sm text-cyan-200">{challengeCollapsed ? '+' : '-'}</span>
+          </button>
+          {!challengeCollapsed && (
+            <div id="challenge-panel-content" className="border-t border-gray-800 px-4 py-4 sm:px-5 sm:py-5">
+              <p className="mb-4 text-sm text-cyan-200">{challengeCompletedCount} of 32 colors completed</p>
+              <div className="grid gap-4 lg:grid-cols-2">
+                {[CHALLENGE_LEFT_COLUMN, CHALLENGE_RIGHT_COLUMN].map((column, columnIndex) => (
+                  <div key={`challenge-column-${columnIndex}`} className="space-y-1">
+                    {column.map((identity) => {
+                      const matchingDecks = challengeDecksByIdentity.get(identity.key) ?? [];
+                      return (
+                        <div key={identity.key} className="flex items-start gap-2 text-xs">
+                          <div className="pt-0.5">
+                            <ColorIdentityIcons colors={identity.colors} />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <p className="text-[11px] uppercase tracking-wide text-gray-500">{identity.label}</p>
+                            {matchingDecks.length === 0 && (
+                              <p className="h-5 border-b border-gray-800" aria-hidden="true" />
+                            )}
+                            {matchingDecks.map((deck) => (
+                              <p key={`${identity.key}-${deck.id}`} className="truncate border-b border-gray-800 pb-0.5 text-gray-200">
+                                {deck.name} — {formatCommanderList(deck.commanderNames)}
+                              </p>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
         <div className="mt-6 flex flex-1 min-h-0 flex-col overflow-hidden">
           {loading && <p className="text-gray-400">Loading...</p>}
           {!loading && decks.length === 0 && (
@@ -1730,66 +1766,6 @@ export function DeckCollection({
           )}
       </div>
     </div>
-
-      {challengeModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-gray-950/80 px-3 py-4 sm:items-center sm:px-4 sm:py-6">
-          <div className="w-full max-w-[900px] rounded-2xl border border-gray-700 bg-gray-900 shadow-2xl">
-            <div className="flex items-center justify-between border-b border-gray-800 px-4 py-3 sm:px-5">
-              <h3 className="text-sm font-semibold uppercase tracking-wide text-white">32 Deck Challenge</h3>
-              <button
-                type="button"
-                onClick={() => setChallengeModalOpen(false)}
-                className="rounded-md px-2 py-1 text-sm text-gray-300 hover:bg-gray-800 hover:text-white"
-                aria-label="Close challenge modal"
-              >
-                Close
-              </button>
-            </div>
-            <div className="p-3 sm:p-4">
-              <div
-                className="relative mx-auto w-full overflow-hidden rounded-lg border border-gray-700 bg-cover bg-center"
-                style={{
-                  aspectRatio: '2550 / 3300',
-                  backgroundImage: `url(${CHALLENGE_TEMPLATE_IMAGE_URL})`
-                }}
-              >
-                <div className="absolute inset-0 bg-white/30" />
-                <p className="absolute left-[8.5%] top-[15.6%] z-10 text-[clamp(12px,1.55vw,18px)] font-semibold text-gray-900">
-                  {challengeCompletedCount} of 32 colors completed
-                </p>
-                <div className="absolute left-[17%] top-[35%] z-10 grid h-[53%] w-[30%] grid-rows-16 gap-[0.55%]">
-                  {CHALLENGE_LEFT_COLUMN.map((identity) => {
-                    const matchingDecks = challengeDecksByIdentity.get(identity.key) ?? [];
-                    return (
-                      <div key={`challenge-left-${identity.key}`} className="min-h-0 overflow-hidden text-[clamp(9px,0.94vw,12px)] leading-[1.15] text-gray-900">
-                        {matchingDecks.length > 0 && matchingDecks.map((deck) => (
-                          <p key={`${identity.key}-${deck.id}`} className="truncate">
-                            {deck.name} — {formatCommanderList(deck.commanderNames)}
-                          </p>
-                        ))}
-                      </div>
-                    );
-                  })}
-                </div>
-                <div className="absolute left-[67%] top-[35%] z-10 grid h-[53%] w-[24%] grid-rows-16 gap-[0.55%]">
-                  {CHALLENGE_RIGHT_COLUMN.map((identity) => {
-                    const matchingDecks = challengeDecksByIdentity.get(identity.key) ?? [];
-                    return (
-                      <div key={`challenge-right-${identity.key}`} className="min-h-0 overflow-hidden text-[clamp(9px,0.94vw,12px)] leading-[1.15] text-gray-900">
-                        {matchingDecks.length > 0 && matchingDecks.map((deck) => (
-                          <p key={`${identity.key}-${deck.id}`} className="truncate">
-                            {deck.name} — {formatCommanderList(deck.commanderNames)}
-                          </p>
-                        ))}
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
 
       {deckModalOpen && (
         <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-gray-950/70 px-4 py-6 sm:items-center sm:py-8">

--- a/client/src/components/DeckCollection.tsx
+++ b/client/src/components/DeckCollection.tsx
@@ -1529,8 +1529,8 @@ export function DeckCollection({
                     {column.map((identity) => {
                       const matchingDecks = challengeDecksByIdentity.get(identity.key) ?? [];
                       return (
-                        <div key={identity.key} className="flex items-start gap-2 text-xs">
-                          <div className="pt-0.5">
+                        <div key={identity.key} className="grid grid-cols-[5.75rem_minmax(0,1fr)] items-start gap-2 text-xs">
+                          <div className="flex justify-end pt-0.5">
                             <ColorIdentityIcons colors={identity.colors} />
                           </div>
                           <div className="min-w-0 flex-1">

--- a/client/src/components/DeckCollection.tsx
+++ b/client/src/components/DeckCollection.tsx
@@ -1539,9 +1539,23 @@ export function DeckCollection({
                               <p className="h-5 border-b border-gray-800" aria-hidden="true" />
                             )}
                             {matchingDecks.map((deck) => (
-                              <p key={`${identity.key}-${deck.id}`} className="truncate border-b border-gray-800 pb-0.5 text-gray-200">
-                                {deck.name} — {formatCommanderList(deck.commanderNames)}
-                              </p>
+                              <div key={`${identity.key}-${deck.id}`} className="truncate border-b border-gray-800 pb-0.5 text-gray-200">
+                                {deck.url ? (
+                                  <a
+                                    href={deck.url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="text-cyan-200 hover:text-cyan-100"
+                                  >
+                                    {deck.name}
+                                  </a>
+                                ) : (
+                                  <span>{deck.name}</span>
+                                )}
+                                {deck.commanderNames.length > 0 && (
+                                  <span className="text-gray-300"> — {renderCommanderList(deck)}</span>
+                                )}
+                              </div>
                             ))}
                           </div>
                         </div>

--- a/client/src/components/DeckCollection.tsx
+++ b/client/src/components/DeckCollection.tsx
@@ -1523,13 +1523,13 @@ export function DeckCollection({
           {!challengeCollapsed && (
             <div id="challenge-panel-content" className="border-t border-gray-800 px-4 py-4 sm:px-5 sm:py-5">
               <p className="mb-4 text-sm text-cyan-200">{challengeCompletedCount} of 32 colors completed</p>
-              <div className="grid gap-4 lg:grid-cols-2">
+              <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
                 {[CHALLENGE_LEFT_COLUMN, CHALLENGE_RIGHT_COLUMN].map((column, columnIndex) => (
                   <div key={`challenge-column-${columnIndex}`} className="space-y-1">
                     {column.map((identity) => {
                       const matchingDecks = challengeDecksByIdentity.get(identity.key) ?? [];
                       return (
-                        <div key={identity.key} className="grid grid-cols-[5.75rem_minmax(0,1fr)] items-start gap-2 text-xs">
+                        <div key={identity.key} className="grid grid-cols-[4.75rem_minmax(0,1fr)] items-start gap-2 text-xs sm:grid-cols-[5.75rem_minmax(0,1fr)]">
                           <div className="flex justify-end pt-0.5">
                             <ColorIdentityIcons colors={identity.colors} />
                           </div>
@@ -1539,7 +1539,7 @@ export function DeckCollection({
                               <p className="h-5 border-b border-gray-800" aria-hidden="true" />
                             )}
                             {matchingDecks.map((deck) => (
-                              <div key={`${identity.key}-${deck.id}`} className="truncate border-b border-gray-800 pb-0.5 text-gray-200">
+                              <div key={`${identity.key}-${deck.id}`} className="border-b border-gray-800 pb-0.5 text-gray-200 break-words">
                                 {deck.url ? (
                                   <a
                                     href={deck.url}


### PR DESCRIPTION
## Summary
- add a 32 Deck Challenge panel to Deck Collection
- show per-color-identity deck entries using deck name and commander(s)
- show `X of 32 colors completed` based on identities with at least one matching deck
- render multiple matching decks on separate lines for the same identity

Closes #89