### PR TITLE
[codex] Update OpenAI Agents SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1199,9 +1199,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.7",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
-      "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1428,13 +1428,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
-      "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.7",
+        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1442,14 +1442,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -1468,9 +1469,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1505,35 +1506,35 @@
       }
     },
     "node_modules/@openai/agents": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.3.7.tgz",
-      "integrity": "sha512-9QKr6Gqb0yy0VLsyKSjxUoHHxN8j0fqtlZ1YTNmo2j5SqRcFG5LdSVyaQbkeJ3sWsCUugCXvEBEir7yAbxjSRw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.8.3.tgz",
+      "integrity": "sha512-VmUywYNVaOuBOOv5hdH6tj3UjU3ZOkvM5WyRyEgRXEVkYbISkZuVWlnzEtiZkQ3lWjp0M8GGtKfSq2Dbr5DaQQ==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.3.7",
-        "@openai/agents-openai": "0.3.7",
-        "@openai/agents-realtime": "0.3.7",
+        "@openai/agents-core": "0.8.3",
+        "@openai/agents-openai": "0.8.3",
+        "@openai/agents-realtime": "0.8.3",
         "debug": "^4.4.0",
-        "openai": "^6"
+        "openai": "^6.26.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.40 || ^4.0"
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@openai/agents-core": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.3.7.tgz",
-      "integrity": "sha512-Ya1sPc8UyHXxgQjNWN1sn/vFNP4CRdT/0SWd0tIc+kHgYuxrvRjwSfWNBqXc70XOZGS5bWWaRTqJBMwQt6AlYg==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.8.3.tgz",
+      "integrity": "sha512-UWRwtGF4t+MkT2xMWTHuEUI2xgp58bKvMYN0rQu6rB9zWtiP0aY5tCXlWUdPKhpPlM/X68u6eUN7qDitqrf50g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
-        "openai": "^6"
+        "openai": "^6.26.0"
       },
       "optionalDependencies": {
-        "@modelcontextprotocol/sdk": "^1.24.0"
+        "@modelcontextprotocol/sdk": "^1.26.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.40 || ^4.0"
+        "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
         "zod": {
@@ -1542,32 +1543,32 @@
       }
     },
     "node_modules/@openai/agents-openai": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.3.7.tgz",
-      "integrity": "sha512-xjFNFeKDt3TkAWfoXhvUG3sdBQJ/R3FWd/s3Dv1rt1fdcFCaS1BUKkXX1fu79oo24H5DV8zZJfuUu6Bgi0ZAHw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.8.3.tgz",
+      "integrity": "sha512-n5bsRfVDINupkeSh/E/lRoGWUi9xVSRpf6muRjnEckIO0pmCG3NzKO+FQVhiyFA3c8i2vrn28SXF/ZdGcG4+vQ==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.3.7",
+        "@openai/agents-core": "0.8.3",
         "debug": "^4.4.0",
-        "openai": "^6"
+        "openai": "^6.26.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.40 || ^4.0"
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@openai/agents-realtime": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.3.7.tgz",
-      "integrity": "sha512-8zKu33Q8bmXCkReR7UOWQa1rNbIaLwqI4QgjMD20ALaEkuRglRZeaJyfVTIhTcw9COIF35uyiq+GugxFUvPE5A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.8.3.tgz",
+      "integrity": "sha512-no5AdAfYM5V/1u32OEQpP+VOJP/Y/JyTCVOvcgAdSKIV43ZG82f72pxbB0B2aFRdLZwC7C6sDgCJz6pbp+TjRg==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.3.7",
+        "@openai/agents-core": "0.8.3",
         "@types/ws": "^8.18.1",
         "debug": "^4.4.0",
         "ws": "^8.18.1"
       },
       "peerDependencies": {
-        "zod": "^3.25.40 || ^4.0"
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -3286,9 +3287,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5144,9 +5145,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.7.tgz",
+      "integrity": "sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5207,11 +5208,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -5793,12 +5797,11 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
-      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5976,6 +5979,16 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -6165,9 +6178,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -7911,9 +7924,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.15.0.tgz",
-      "integrity": "sha512-F1Lvs5BoVvmZtzkUEVyh8mDQPPFolq4F+xdsx/DO8Hee8YF3IGAlZqUIsF+DVGhqf4aU0a3bTghsxB6OIsRy1g==",
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -10783,13 +10796,13 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "optional": true,
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {
@@ -10848,12 +10861,12 @@
       "name": "@before-that-resolves/server",
       "version": "1.1.0",
       "dependencies": {
-        "@openai/agents": "^0.3.7",
+        "@openai/agents": "^0.8.3",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "marked": "^12.0.2",
-        "openai": "^6.15.0",
+        "openai": "^6.34.0",
         "pg": "^8.13.3",
         "playwright": "^1.54.1",
         "zod": "^4.3.3"

--- a/server/package.json
+++ b/server/package.json
@@ -15,12 +15,12 @@
     "test:integration": "RUN_INTEGRATION_TESTS=1 vitest run"
   },
   "dependencies": {
-    "@openai/agents": "^0.3.7",
+    "@openai/agents": "^0.8.3",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "marked": "^12.0.2",
-    "openai": "^6.15.0",
+    "openai": "^6.34.0",
     "pg": "^8.13.3",
     "playwright": "^1.54.1",
     "zod": "^4.3.3"

--- a/server/src/tools/card-tools.test.ts
+++ b/server/src/tools/card-tools.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { RunContext } from '@openai/agents';
+import type { FunctionTool, RunContext, ToolInputParameters } from '@openai/agents';
 import type { Card } from '../types/shared';
 
 const mockSearchCardByName = vi.fn();
@@ -18,9 +18,7 @@ vi.mock('../services/scryfall', () => ({
   }
 }));
 
-type ToolInvoker = {
-  invoke: (runContext: RunContext<unknown>, input: string, details?: { toolCall: unknown }) => Promise<unknown>;
-};
+type ToolInvoker = Pick<FunctionTool<unknown, ToolInputParameters, unknown>, 'invoke'>;
 
 type ToolCard = {
   name: string;

--- a/server/src/tools/deck-tools.test.ts
+++ b/server/src/tools/deck-tools.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { RunContext } from '@openai/agents';
+import type { FunctionTool, RunContext, ToolInputParameters } from '@openai/agents';
 
 const mockGetLastCachedDeck = vi.fn();
 const mockGetLastCachedDeckRaw = vi.fn();
@@ -9,9 +9,7 @@ vi.mock('../services/deck', () => ({
   getLastCachedDeckRaw: mockGetLastCachedDeckRaw
 }));
 
-type ToolInvoker = {
-  invoke: (runContext: RunContext<unknown>, input: string, details?: { toolCall: unknown }) => Promise<unknown>;
-};
+type ToolInvoker = Pick<FunctionTool<unknown, ToolInputParameters, unknown>, 'invoke'>;
 
 async function invokeTool<TInput, TResult>(
   tool: ToolInvoker,

--- a/server/src/tools/goldfish/index.test.ts
+++ b/server/src/tools/goldfish/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { RunContext } from '@openai/agents';
+import type { FunctionTool, RunContext, ToolInputParameters } from '@openai/agents';
 
 const mockGetLastCachedDeck = vi.fn();
 
@@ -24,9 +24,7 @@ function buildDeck(cardCount: number, commanderName: string) {
   };
 }
 
-type ToolInvoker = {
-  invoke: (runContext: RunContext<unknown>, input: string, details?: { toolCall: unknown }) => Promise<unknown>;
-};
+type ToolInvoker = Pick<FunctionTool<unknown, ToolInputParameters, unknown>, 'invoke'>;
 
 async function invokeTool<TInput, TResult>(
   tool: ToolInvoker,

--- a/server/src/tools/goldfish/index.ts
+++ b/server/src/tools/goldfish/index.ts
@@ -176,7 +176,7 @@ export const reset = tool({
 
     resetZones();
     cardIdCounter = 1;
-    setSeed(seed);
+    setSeed(seed ?? undefined);
 
     const library = expandDeckList(deckList);
     const removedCommander = removeFirstByName(library, commanderName);
@@ -284,7 +284,7 @@ export const moveById = tool({
   }),
   execute: async ({ cardId, fromZone, toZone, toLibraryPosition }) => {
     const destination = toZone as Zone;
-    if (!canMoveToLibrary(toZone, toLibraryPosition)) {
+    if (!canMoveToLibrary(toZone, toLibraryPosition ?? undefined)) {
       console.warn(`⚠️ Goldfish moveById invalid library position for ${cardId}.`);
       return { ok: false };
     }
@@ -328,7 +328,7 @@ export const findAndMoveByName = tool({
     const destination = (toZone ?? 'hand') as Zone;
     const shouldShuffle = shuffleLibraryAfter ?? true;
 
-    if (!canMoveToLibrary(destination, toLibraryPosition)) {
+    if (!canMoveToLibrary(destination, toLibraryPosition ?? undefined)) {
       console.warn(`⚠️ Goldfish findAndMoveByName invalid library position for ${cardName}.`);
       return { ok: false, movedCard: null };
     }


### PR DESCRIPTION
## What changed

- Updated `@openai/agents` from `^0.3.7` to `^0.8.3`.
- Updated `openai` from `^6.15.0` to `^6.34.0` to align with the latest Agents SDK dependency expectations.
- Adjusted server tool tests to use the SDK's exported `FunctionTool` / `ToolInputParameters` types.
- Normalized nullable optional goldfish tool inputs before passing them to stricter internal helpers.

## Why

This brings the app onto the current OpenAI Agents SDK line before adding provider abstraction work for Anthropic/Claude support. The newer SDK has stricter types around tool invocation details and nullable tool inputs, so the compatibility changes are intentionally narrow.

## Notes

`npm audit` still reports unrelated dependency advisories. Those are intentionally not included here so this PR stays focused on the Agents SDK update.

## Validation

- `npm test`
- `npm run build`
- `npm run lint`