### PR TITLE
Add Anthropic Claude provider support alongside OpenAI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ This file provides guidance to coding agents working in this repository.
 Before That Resolves is a Magic: The Gathering assistant web app. Users chat with "The Oracle" to look up cards, check commander legality, explain interactions, analyze decks, and track game logs/deck collections.
 
 Primary integrations:
-- OpenAI API (agent responses)
+- OpenAI API (agent responses, default provider)
+- Anthropic Claude API (agent responses, via `@openai/agents-extensions` AI SDK adapter)
 - Scryfall API (card data)
 - Archidekt/Moxfield APIs (deck loading/import)
 - PostgreSQL (auth sessions, deck collections, game logs)
@@ -24,7 +25,9 @@ Key directories/files:
 - `server/src/app.ts` - Express app, routes, dependency injection entrypoint
 - `server/src/agents/card-oracle/index.ts` - main agent orchestration
 - `server/src/services/deck.ts` - Archidekt/Moxfield loading + in-memory deck cache
-- `server/src/utils/conversation-store.ts` - conversation state (`lastResponseId`) storage
+- `server/src/utils/conversation-store.ts` - provider-aware conversation state (OpenAI: `lastResponseId`; Anthropic: message history)
+- `server/src/config/model-provider.ts` - resolves `OracleModelSelection` → model instance + runConfig for either provider
+- `server/src/types/provider.ts` - `ModelProviderKind` and `OracleModelSelection` shared types
 - `server/src/services/db.ts` - Postgres pool + schema initialization
 - `docs/architecture.md`, `docs/agents.md`, `docs/interaction.md` - architecture and flows
 
@@ -42,6 +45,7 @@ npm run test --workspace=client
 npm run test --workspace=server
 npm run test:integration --workspace=server          # RUN_INTEGRATION_TESTS=1
 npm run test:live --workspace=server                 # RUN_LIVE_TESTS=1, requires OPENAI_API_KEY
+RUN_ANTHROPIC_LIVE_TESTS=1 npm run test:live --workspace=server  # requires ANTHROPIC_API_KEY
 
 # Single test file
 npx vitest run path/to/file.test.ts --workspace=client
@@ -60,8 +64,9 @@ export DATABASE_URL=postgresql://btr:btr@localhost:5432/btr
 ```
 
 Important env behavior:
-- App chat requests use per-request `x-openai-key` from the UI; server does not require a global `OPENAI_API_KEY` for normal local usage.
-- `OPENAI_API_KEY` is still needed for server live tests and standalone test scripts.
+- App chat requests use per-request `x-openai-key` or `x-anthropic-key` from the UI; server does not require global API keys for normal local usage.
+- `OPENAI_API_KEY` is needed for OpenAI live tests and standalone test scripts.
+- `ANTHROPIC_API_KEY` is needed for Anthropic live tests (gated by `RUN_ANTHROPIC_LIVE_TESTS=1`).
 - `MOXFIELD_USER_AGENT` must be set for Moxfield deck fetch/import endpoints.
 - `GOOGLE_CLIENT_ID` is required for Google auth flows.
 
@@ -77,19 +82,26 @@ See `.env.example` for full list.
   - Goldfish Expert
 
 **Core data flow:**
-1. Client sends query to `/api/agent/query`.
-2. Server resolves/creates `conversationId` and forwards to Card Oracle.
-3. Agent runs tools (Scryfall, deck cache access, sub-agents).
-4. Server returns response plus `conversationId`; conversation history uses `lastResponseId`.
+1. Client sends query to `/api/agent/query` with `provider` (`'openai'` or `'anthropic'`) and the matching API key header.
+2. Server resolves/creates `conversationId`, builds an `OracleModelSelection`, and forwards to Card Oracle.
+3. `buildProviderConfig` resolves the model instance and `runConfig` for the selected provider.
+4. Agent runs tools (Scryfall, deck cache access, sub-agents) — all agents use the same provider.
+5. Server stores conversation state per-provider and returns the response with `conversationId`.
 
 **State model:**
 - Conversation state is in-memory and keyed by `conversationId`.
+  - OpenAI: stores `lastResponseId` (Responses API chain).
+  - Anthropic: stores full message history (`AgentInputItem[]`) passed on the next turn.
 - Deck cache is also in-memory and keyed by `conversationId`.
 - `/api/agent/reset` clears both conversation state and deck cache for that conversation.
 
 ## API Surface (High Value Routes)
 
-- `POST /api/agent/query` - main oracle chat endpoint (`x-openai-key` supported)
+- `POST /api/agent/query` - main oracle chat endpoint
+  - Body: `{ query, conversationId?, provider?, model?, reasoningEffort?, verbosity?, deckUrl? }`
+  - `provider`: `'openai'` (default) or `'anthropic'`
+  - Headers: `x-openai-key` for OpenAI, `x-anthropic-key` for Anthropic
+  - `reasoningEffort` and `verbosity` are OpenAI-only; ignored for Anthropic
 - `POST /api/agent/reset` - reset conversation + deck cache for `conversationId`
 - `POST /api/deck/cache` - cache deck for a conversation
 - `POST /api/chat/export-pdf` - export chat transcript PDF
@@ -101,6 +113,7 @@ See `.env.example` for full list.
 - Server app uses dependency injection via `createApp(deps)` in `server/src/app.ts`
 - Integration tests use Testcontainers + PostgreSQL and are gated by `RUN_INTEGRATION_TESTS=1`
 - Live OpenAI tests are gated by `RUN_LIVE_TESTS=1` and require `OPENAI_API_KEY`
+- Live Anthropic tests are gated by `RUN_ANTHROPIC_LIVE_TESTS=1` and require `ANTHROPIC_API_KEY`; not run in default CI
 
 ## Domain Conventions
 

--- a/README.md
+++ b/README.md
@@ -2,29 +2,37 @@
 
 Before That Resolves is a local web app that lets you chat with a Magic: The Gathering assistant. It can look up cards and rules, check commander legality, explain interactions, and summarize Commander decklists from Archidekt or Moxfield.
 
-The app runs entirely on your machine and calls OpenAI’s API for answers, so you will need your own OpenAI API key.
+The app runs entirely on your machine and uses an LLM provider for answers. It supports both **OpenAI** and **Anthropic Claude** — you supply your own API key for whichever provider you choose.
 
 ## How It Works
 
 - You open the app in a browser and chat with “The Oracle.”
 - The Oracle uses Scryfall for real card data and can load decklists from Archidekt or Moxfield.
 - Responses include Scryfall links that show a card image on hover.
-- You can choose which OpenAI model to use and (for supported models) set reasoning and text verbosity.
+- You choose a provider (OpenAI or Anthropic) and model in the AI Options panel. Each provider uses its own API key stored locally in your browser.
 
 ## Requirements
 
 - Node.js 18+ and npm
-- An OpenAI API key
+- An API key for either OpenAI or Anthropic (or both)
 
-### Install Node.js and npm (macOS + Homebrew)
+### Install Node.js and npm
 
-If you don’t already have Node.js and npm installed, Homebrew is the easiest way:
+**macOS (Homebrew):**
 
 ```bash
 brew install node
 ```
 
-This installs both `node` and `npm`. You can verify:
+**Windows:**
+
+Download and run the installer from https://nodejs.org (LTS version recommended), or use winget:
+
+```powershell
+winget install OpenJS.NodeJS.LTS
+```
+
+Verify either way:
 
 ```bash
 node -v
@@ -33,26 +41,28 @@ npm -v
 
 ## Get an API Key
 
-1. Create an OpenAI account at https://platform.openai.com
-2. Create an API key in your account
-3. Keep it private
+### OpenAI
 
-## Create an OpenAI Account (ChatGPT + API)
+1. Visit https://platform.openai.com and sign in (or create an account).
+2. Go to “API keys” and create a new key.
+3. Copy the key somewhere safe — it starts with `sk-`.
 
-1. Visit https://chat.openai.com and create a ChatGPT account (or sign in if you already have one).
-2. Visit https://platform.openai.com and sign in with the same account.
-3. Go to “API keys” and create a new key.
-4. Copy the key somewhere safe and keep it private.
+### Anthropic Claude
+
+1. Visit https://console.anthropic.com and sign in (or create an account).
+2. Go to “API keys” and create a new key.
+3. Copy the key somewhere safe — it starts with `sk-ant-`.
 
 ## Set the API Key
 
-The app always uses a user-provided key from the UI.
+The app always uses a user-provided key from the UI — keys are never stored server-side.
 
-1. Start the app and open the sidebar section titled "OpenAI API key".
-2. Paste your key.
-3. Optionally check "Store this key in this browser" to keep it in local storage.
+1. Start the app and open the **AI Options** section in the sidebar.
+2. Select your provider (OpenAI or Anthropic) using the toggle at the top.
+3. Paste your key for that provider into the key field.
+4. Optionally check “Store this key in this browser” to persist it in local storage.
 
-The key is sent with each request to the local server and is never stored server-side.
+Switching providers shows the key input for that provider only. Each key is stored independently.
 
 ## Run Locally
 
@@ -66,8 +76,19 @@ Then open http://localhost:5173 in your browser.
 
 Required env (example):
 
+**macOS/Linux:**
 ```bash
 export DATABASE_URL=postgresql://btr:btr@localhost:5432/btr
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:DATABASE_URL="postgresql://btr:btr@localhost:5432/btr"
+```
+
+**Windows (Command Prompt):**
+```cmd
+set DATABASE_URL=postgresql://btr:btr@localhost:5432/btr
 ```
 
 PDF export (optional):
@@ -88,7 +109,7 @@ For local Docker or Cloud Run container notes, see `deploy/README.md`.
 
 ## Troubleshooting
 
-- If you see “OpenAI API key is required,” paste a key in the UI and try again.
+- If you see “OpenAI API key is required” or “Anthropic API key is required,” paste the correct key for your selected provider in the AI Options panel and try again.
 - If the app can’t connect, make sure the server is running on port 3001.
 
 ## Running Tests
@@ -111,9 +132,31 @@ Backend integration tests (requires Docker, uses Testcontainers):
 npm run test:integration --workspace=server
 ```
 
-Live integration tests (calls the OpenAI API; uses a key only for these tests):
+Live integration tests — OpenAI (calls the OpenAI API):
 
+**macOS/Linux:**
 ```bash
-export OPENAI_API_KEY="your_api_key_here"
+export OPENAI_API_KEY="your_openai_key"
+npm run test:live --workspace=server
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:OPENAI_API_KEY="your_openai_key"
+npm run test:live --workspace=server
+```
+
+Live integration tests — Anthropic (calls the Anthropic API; not run in default CI):
+
+**macOS/Linux:**
+```bash
+export ANTHROPIC_API_KEY="your_anthropic_key"
+RUN_ANTHROPIC_LIVE_TESTS=1 npm run test:live --workspace=server
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:ANTHROPIC_API_KEY="your_anthropic_key"
+$env:RUN_ANTHROPIC_LIVE_TESTS="1"
 npm run test:live --workspace=server
 ```

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,12 +8,15 @@ import { DevPanel } from './components/DevPanel';
 import { useDeckCollection } from './hooks/useDeckCollection';
 import { useSharedGameLogs } from './hooks/useSharedGameLogs';
 
+const PROVIDER_STORAGE_KEY = 'before-that-resolves.provider';
+
 const reasoningOptions = {
   'gpt-5': ['low', 'medium', 'high'],
   'gpt-5.1': ['low', 'medium', 'high'],
   'gpt-5.2': ['low', 'medium', 'high']
 } as const;
 
+type Provider = 'openai' | 'anthropic';
 type AppView = 'oracle' | 'decks' | 'logs' | 'profile';
 
 type NavItem = {
@@ -34,7 +37,7 @@ function getInitials(label?: string | null) {
 }
 
 function App() {
-  const models = useMemo(
+  const openaiModels = useMemo(
     () => [
       { id: 'gpt-5', label: 'gpt-5', reasoning: true, verbosity: true },
       { id: 'gpt-5.1', label: 'gpt-5.1', reasoning: true, verbosity: true },
@@ -45,7 +48,28 @@ function App() {
     ],
     []
   );
-  const [selectedModel, setSelectedModel] = useState('gpt-5.2');
+  const anthropicModels = useMemo(
+    () => [
+      { id: 'claude-sonnet-4-6', label: 'claude-sonnet-4-6' },
+      { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },
+      { id: 'claude-opus-4-7', label: 'claude-opus-4-7' }
+    ],
+    []
+  );
+  const [provider, setProviderState] = useState<Provider>(() => {
+    const stored = window.localStorage.getItem(PROVIDER_STORAGE_KEY);
+    return stored === 'anthropic' ? 'anthropic' : 'openai';
+  });
+  const setProvider = (next: Provider) => {
+    setProviderState(next);
+    window.localStorage.setItem(PROVIDER_STORAGE_KEY, next);
+    setSelectedModel(next === 'anthropic' ? 'claude-sonnet-4-6' : 'gpt-5.2');
+  };
+  const models = provider === 'anthropic' ? anthropicModels : openaiModels;
+  const [selectedModel, setSelectedModel] = useState(() => {
+    const stored = window.localStorage.getItem(PROVIDER_STORAGE_KEY);
+    return stored === 'anthropic' ? 'claude-sonnet-4-6' : 'gpt-5.2';
+  });
   const [reasoningEffort, setReasoningEffort] = useState<'low' | 'medium' | 'high'>('medium');
   const [verbosity, setVerbosity] = useState<'low' | 'medium' | 'high'>('medium');
   const [view, setView] = useState<AppView>('oracle');
@@ -59,21 +83,45 @@ function App() {
     onAuthExpired: deckCollection.markAuthExpired
   });
   const mainRef = useRef<HTMLElement | null>(null);
-  const supportsReasoning = models.find((model) => model.id === selectedModel)?.reasoning ?? false;
-  const supportsVerbosity = models.find((model) => model.id === selectedModel)?.verbosity ?? false;
+  const openaiModelMeta = openaiModels.find((m) => m.id === selectedModel);
+  const supportsReasoning = provider === 'openai' && (openaiModelMeta?.reasoning ?? false);
+  const supportsVerbosity = provider === 'openai' && (openaiModelMeta?.verbosity ?? false);
   const effortOptions = useMemo(() => {
-    if (!supportsReasoning) {
-      return [];
-    }
+    if (!supportsReasoning) return [];
     return Array.from(reasoningOptions[selectedModel as keyof typeof reasoningOptions] || []);
   }, [supportsReasoning, selectedModel]);
   const normalizedReasoningEffort =
-    supportsReasoning && effortOptions.includes(reasoningEffort)
-      ? reasoningEffort
-      : 'medium';
+    supportsReasoning && effortOptions.includes(reasoningEffort) ? reasoningEffort : 'medium';
   const normalizedVerbosity = supportsVerbosity ? verbosity : 'medium';
   const modelControls = (
     <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <label className="text-sm text-gray-300">Provider</label>
+        <div className="flex rounded overflow-hidden border border-gray-700 text-sm">
+          <button
+            type="button"
+            onClick={() => setProvider('openai')}
+            className={`flex-1 px-3 py-2 transition-colors ${
+              provider === 'openai'
+                ? 'bg-cyan-600 text-white'
+                : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+            }`}
+          >
+            OpenAI
+          </button>
+          <button
+            type="button"
+            onClick={() => setProvider('anthropic')}
+            className={`flex-1 px-3 py-2 transition-colors ${
+              provider === 'anthropic'
+                ? 'bg-cyan-600 text-white'
+                : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+            }`}
+          >
+            Anthropic
+          </button>
+        </div>
+      </div>
       <div className="flex flex-col gap-2">
         <label className="text-sm text-gray-300">Model</label>
         <select
@@ -301,6 +349,7 @@ function App() {
               </div>
               {view === 'oracle' && (
                 <CardOracle
+                  provider={provider}
                   model={selectedModel}
                   reasoningEffort={supportsReasoning ? reasoningEffort : undefined}
                   verbosity={supportsVerbosity ? verbosity : undefined}

--- a/client/src/components/CardOracle.tsx
+++ b/client/src/components/CardOracle.tsx
@@ -6,6 +6,7 @@ import { RichMTGText } from './RichMTGText';
 import { DeveloperInfo } from './DeveloperInfo';
 
 const OPENAI_KEY_STORAGE_KEY = 'before-that-resolves.openai-key';
+const ANTHROPIC_KEY_STORAGE_KEY = 'before-that-resolves.anthropic-key';
 type ErrorWithResponse = {
   response?: { data?: { error?: string } };
   message?: string;
@@ -21,6 +22,7 @@ function createConversationId() {
 }
 
 type CardOracleProps = {
+  provider?: 'openai' | 'anthropic';
   model?: string;
   reasoningEffort?: 'low' | 'medium' | 'high';
   verbosity?: 'low' | 'medium' | 'high';
@@ -32,6 +34,7 @@ type CardOracleProps = {
 type MobilePanel = 'chat' | 'deck' | 'ai';
 
 export function CardOracle({
+  provider = 'openai',
   model,
   reasoningEffort,
   verbosity,
@@ -95,18 +98,31 @@ export function CardOracle({
   const [openAiKey, setOpenAiKey] = useState('');
   const [saveKeyLocally, setSaveKeyLocally] = useState(false);
   const [showKey, setShowKey] = useState(false);
+  const [anthropicKey, setAnthropicKey] = useState('');
+  const [saveAnthropicKeyLocally, setSaveAnthropicKeyLocally] = useState(false);
+  const [showAnthropicKey, setShowAnthropicKey] = useState(false);
   const [messages, setMessages] = useState<
     Array<{ id: string; role: 'user' | 'agent' | 'error'; content: string }>
   >([]);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const requestControllerRef = useRef<AbortController | null>(null);
-  const hasApiKey = Boolean(openAiKey.trim());
+  const prevProviderRef = useRef(provider);
+  const activeKey = provider === 'anthropic' ? anthropicKey.trim() : openAiKey.trim();
+  const hasApiKey = Boolean(activeKey);
 
   useEffect(() => {
     const storedKey = window.localStorage.getItem(OPENAI_KEY_STORAGE_KEY);
     if (storedKey) {
       setOpenAiKey(storedKey);
       setSaveKeyLocally(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    const storedKey = window.localStorage.getItem(ANTHROPIC_KEY_STORAGE_KEY);
+    if (storedKey) {
+      setAnthropicKey(storedKey);
+      setSaveAnthropicKeyLocally(true);
     }
   }, []);
 
@@ -122,6 +138,26 @@ export function CardOracle({
     }
     window.localStorage.setItem(OPENAI_KEY_STORAGE_KEY, trimmedKey);
   }, [openAiKey, saveKeyLocally]);
+
+  useEffect(() => {
+    if (!saveAnthropicKeyLocally) {
+      window.localStorage.removeItem(ANTHROPIC_KEY_STORAGE_KEY);
+      return;
+    }
+    const trimmedKey = anthropicKey.trim();
+    if (!trimmedKey) {
+      window.localStorage.removeItem(ANTHROPIC_KEY_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(ANTHROPIC_KEY_STORAGE_KEY, trimmedKey);
+  }, [anthropicKey, saveAnthropicKeyLocally]);
+
+  useEffect(() => {
+    if (prevProviderRef.current !== provider) {
+      prevProviderRef.current = provider;
+      setConversationId(createConversationId());
+    }
+  }, [provider]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -161,6 +197,11 @@ export function CardOracle({
 
   const getApiKeyHeaders = () => {
     if (!useOwnKey) return null;
+    if (provider === 'anthropic') {
+      const trimmedKey = anthropicKey.trim();
+      if (!trimmedKey) return null;
+      return { 'x-anthropic-key': trimmedKey };
+    }
     const trimmedKey = openAiKey.trim();
     if (!trimmedKey) return null;
     return { 'x-openai-key': trimmedKey };
@@ -200,8 +241,10 @@ export function CardOracle({
     options?: { hideUserMessage?: boolean; mode?: 'query' | 'analyze' | 'goldfish' }
   ) => {
     if (!text.trim()) return;
-    if (useOwnKey && !openAiKey.trim()) {
-      appendErrorMessage('OpenAI API key is required.');
+    if (useOwnKey && !activeKey) {
+      appendErrorMessage(
+        provider === 'anthropic' ? 'Anthropic API key is required.' : 'OpenAI API key is required.'
+      );
       return;
     }
 
@@ -226,6 +269,7 @@ export function CardOracle({
           query: text,
           devMode: isDevMode,
           conversationId,
+          provider,
           model,
           reasoningEffort: reasoningEffort || undefined,
           verbosity,
@@ -1163,31 +1207,63 @@ export function CardOracle({
       {showModelOptions && (
         <div className="mt-3 flex flex-col gap-4">
           <div className="flex flex-col gap-3 text-sm text-gray-300">
-            <div className="flex items-center gap-2">
-              <input
-                type={showKey ? 'text' : 'password'}
-                value={openAiKey}
-                onChange={(e) => setOpenAiKey(e.target.value)}
-                placeholder="sk-..."
-                className="flex-1 rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-cyan-500"
-              />
-              <button
-                type="button"
-                onClick={() => setShowKey((prev) => !prev)}
-                className="text-xs text-gray-300 border border-gray-600 rounded px-2 py-1 hover:text-white hover:border-gray-400 transition-colors"
-              >
-                {showKey ? 'Hide' : 'Show'}
-              </button>
-            </div>
-            <label className="flex items-center gap-2 text-xs text-gray-400">
-              <input
-                type="checkbox"
-                checked={saveKeyLocally}
-                onChange={(e) => setSaveKeyLocally(e.target.checked)}
-                className="h-4 w-4 rounded border-gray-500 bg-gray-800 text-cyan-500 focus:ring-cyan-500"
-              />
-              Store this key in this browser (local storage)
-            </label>
+            {provider === 'anthropic' ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <input
+                    type={showAnthropicKey ? 'text' : 'password'}
+                    value={anthropicKey}
+                    onChange={(e) => setAnthropicKey(e.target.value)}
+                    placeholder="sk-ant-..."
+                    className="flex-1 rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowAnthropicKey((prev) => !prev)}
+                    className="text-xs text-gray-300 border border-gray-600 rounded px-2 py-1 hover:text-white hover:border-gray-400 transition-colors"
+                  >
+                    {showAnthropicKey ? 'Hide' : 'Show'}
+                  </button>
+                </div>
+                <label className="flex items-center gap-2 text-xs text-gray-400">
+                  <input
+                    type="checkbox"
+                    checked={saveAnthropicKeyLocally}
+                    onChange={(e) => setSaveAnthropicKeyLocally(e.target.checked)}
+                    className="h-4 w-4 rounded border-gray-500 bg-gray-800 text-cyan-500 focus:ring-cyan-500"
+                  />
+                  Store this key in this browser (local storage)
+                </label>
+              </>
+            ) : (
+              <>
+                <div className="flex items-center gap-2">
+                  <input
+                    type={showKey ? 'text' : 'password'}
+                    value={openAiKey}
+                    onChange={(e) => setOpenAiKey(e.target.value)}
+                    placeholder="sk-..."
+                    className="flex-1 rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowKey((prev) => !prev)}
+                    className="text-xs text-gray-300 border border-gray-600 rounded px-2 py-1 hover:text-white hover:border-gray-400 transition-colors"
+                  >
+                    {showKey ? 'Hide' : 'Show'}
+                  </button>
+                </div>
+                <label className="flex items-center gap-2 text-xs text-gray-400">
+                  <input
+                    type="checkbox"
+                    checked={saveKeyLocally}
+                    onChange={(e) => setSaveKeyLocally(e.target.checked)}
+                    className="h-4 w-4 rounded border-gray-500 bg-gray-800 text-cyan-500 focus:ring-cyan-500"
+                  />
+                  Store this key in this browser (local storage)
+                </label>
+              </>
+            )}
             <span className="text-[11px] text-gray-500">
               Keys are required for requests and are never stored by the server. Remove the
               stored key by unchecking the option above and clearing the field.

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -1,6 +1,32 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+// jsdom 25 removed the built-in localStorage/sessionStorage implementation.
+// Provide a working in-memory mock so tests can use the standard Storage API.
+const createStorageMock = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string): string | null => store.get(key) ?? null,
+    setItem: (key: string, value: string): void => { store.set(key, String(value)); },
+    removeItem: (key: string): void => { store.delete(key); },
+    clear: (): void => { store.clear(); },
+    get length(): number { return store.size; },
+    key: (index: number): string | null => [...store.keys()][index] ?? null,
+  };
+};
+
+Object.defineProperty(window, 'localStorage', {
+  value: createStorageMock(),
+  writable: true,
+  configurable: true,
+});
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: createStorageMock(),
+  writable: true,
+  configurable: true,
+});
+
 Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
   value: () => {},
   writable: true

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -43,6 +43,8 @@ graph TD
 - Two sub-agents are exposed as tools to the main agent:
   - **Commander Bracket Expert** for bracket system analysis.
   - **Goldfish Expert** for simulation-based analytics using goldfish tools.
+- All agents (main and sub-agents) use the same provider and model selection. The `OracleModelSelection` (provider, model, apiKey) is threaded through run context so sub-agents are constructed with the same provider as the parent.
+- `agent.asTool()` behavior with the Anthropic AI SDK adapter is verified during live testing. If it proves unreliable, sub-agents may fall back to explicit function tools.
 
 ## Goldfish Agent Toolchain
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,11 +15,13 @@ graph TD
     DeckCache[Deck Cache]
     ConvStore[Conversation Store]
     PDF[PDF Export Service]
+    ModelProvider[Model Provider Config]
     Agents[OpenAI Agents SDK]
   end
 
   subgraph External[External Services]
     OpenAI[OpenAI API]
+    Anthropic[Anthropic API]
     Archidekt[Archidekt API]
     Moxfield[Moxfield API]
     Scryfall[Scryfall API]
@@ -33,9 +35,11 @@ graph TD
   API --> DeckCache
   API --> ConvStore
   API --> PDF
-  API --> Agents
+  API --> ModelProvider
+  ModelProvider --> Agents
 
   Agents --> OpenAI
+  Agents -->|via AI SDK adapter| Anthropic
   DeckCache --> Archidekt
   DeckCache --> Moxfield
   Agents --> Scryfall
@@ -46,9 +50,19 @@ graph TD
 - **Web Client**: Collects user input, triggers deck load, analysis/goldfish runs, and PDF export.
 - **Express API**: Orchestrates requests, manages conversation IDs, and forwards agent runs.
 - **Deck Cache**: Stores the most recently loaded deck payload in memory (Archidekt or Moxfield) so tools can query it.
-- **Conversation Store**: Tracks `lastResponseId` per conversation for OpenAI conversation history.
-- **Agents SDK**: Runs the Card Oracle agent and its tools/sub-agents.
+- **Conversation Store**: Tracks provider-aware conversation state per conversation. For OpenAI, stores `lastResponseId` for the Responses API chain. For Anthropic, stores accumulated message history (`AgentInputItem[]`) since Anthropic has no server-side response chain.
+- **Model Provider Config** (`server/src/config/model-provider.ts`): Resolves an `OracleModelSelection` into a model instance compatible with the Agents SDK. Returns a plain model string for OpenAI; wraps an `@ai-sdk/anthropic` model with the `aisdk()` adapter for Anthropic.
+- **Agents SDK**: Runs the Card Oracle agent and its tools/sub-agents. Anthropic models are supported via `@openai/agents-extensions` AI SDK adapter.
 - **PDF Export**: Renders chat transcript (and deck metadata if present) to a PDF.
+
+## Provider Support
+
+The app supports two LLM providers. Provider is selected per-request and defaults to `openai`.
+
+| Provider | Header | Conversation history | Reasoning/verbosity settings |
+|---|---|---|---|
+| `openai` | `x-openai-key` | `previousResponseId` (Responses API) | Supported |
+| `anthropic` | `x-anthropic-key` | Accumulated message history | Not supported (stripped server-side) |
 
 ## Deployment Notes
 

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -13,7 +13,7 @@ sequenceDiagram
   participant Archidekt as Archidekt API
   participant Moxfield as Moxfield API
   participant Agent as Card Oracle Agent
-  participant OpenAI as OpenAI API
+  participant LLM as OpenAI or Anthropic API
 
   User->>UI: Enter Archidekt or Moxfield URL
   User->>UI: Click Load Deck
@@ -28,12 +28,12 @@ sequenceDiagram
   API->>Deck: Store cached deck
   API-->>UI: { success: true }
 
-  User->>UI: Select analysis options
+  User->>UI: Select provider, model, and analysis options
   User->>UI: Click Analyze Deck
-  UI->>API: POST /api/agent/query (x-openai-key required)
-  API->>Agent: executeCardOracle(query)
-  Agent->>OpenAI: run() with tools
-  OpenAI-->>Agent: response
+  UI->>API: POST /api/agent/query { provider, model, ... }<br/>(x-openai-key or x-anthropic-key header)
+  API->>Agent: executeCardOracle(query, modelSelection)
+  Agent->>LLM: run() with tools
+  LLM-->>Agent: response
   Agent-->>API: response text
   API-->>UI: response payload
 ```
@@ -49,14 +49,14 @@ sequenceDiagram
   participant SubAgent as Goldfish Agent
   participant Tools as Goldfish Tools
   participant Deck as Deck Cache
-  participant OpenAI as OpenAI API
+  participant LLM as OpenAI or Anthropic API
 
   User->>UI: Choose goldfish options
   User->>UI: Click Goldfish Deck
-  UI->>API: POST /api/agent/query (x-openai-key required)
-  API->>Agent: executeCardOracle(query)
-  Agent->>OpenAI: run() with tools
-  Agent->>SubAgent: commander_goldfish_expert
+  UI->>API: POST /api/agent/query { provider, model, ... }<br/>(x-openai-key or x-anthropic-key header)
+  API->>Agent: executeCardOracle(query, modelSelection)
+  Agent->>LLM: run() with tools
+  Agent->>SubAgent: commander_goldfish_expert (same provider)
   SubAgent->>Tools: loadDeck()
   Tools->>Deck: read cached deck
   SubAgent->>Tools: reset/draw/move/peek...

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,68 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.72",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.72.tgz",
+      "integrity": "sha512-t0j9mggxylA9uP0hi12NlRk2npYh4QkE7JIpws2MdV/18QzHcsT6+TNGIjbOPayLQDjrmRKx78Ym7iZkg9qRxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.9",
+        "@ai-sdk/provider-utils": "4.0.24"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.105",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.105.tgz",
+      "integrity": "sha512-XpERadvLMHkYGJO4hz1Sw7Y9J705Iex48TmdZLdZdaPiFFtVgiA9qhXugLUWGAxdlXU/2N6ipoPSOwfnULZbXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.9",
+        "@ai-sdk/provider-utils": "4.0.24",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.9.tgz",
+      "integrity": "sha512-/ngMKqKdL9dSlY/eQ3NFDzzFyw0Hix+cbFFlyuKEKcOgpHdBt/spKUvX/i0wGrDLFPYJeVvv3N0j92LxWRL7yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.24.tgz",
+      "integrity": "sha512-oXIw1oLmuBILuvHgSj6w5LOV8oSnFRouPSv0MGkG9sRMeukZ9JnMF17kldaRQaRq8lSJIxo6aS3NzWlVmSb+4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.9",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -1469,9 +1531,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1506,14 +1568,14 @@
       }
     },
     "node_modules/@openai/agents": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.8.3.tgz",
-      "integrity": "sha512-VmUywYNVaOuBOOv5hdH6tj3UjU3ZOkvM5WyRyEgRXEVkYbISkZuVWlnzEtiZkQ3lWjp0M8GGtKfSq2Dbr5DaQQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.8.5.tgz",
+      "integrity": "sha512-OFA7XVV1qXE8lzatvQj080KdSArt8utBExFXRfD5B/R7KT0D+AVaKwg6nLoW3Gxb30vRkIUQf+MaW/Wz+gO3Yg==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.8.3",
-        "@openai/agents-openai": "0.8.3",
-        "@openai/agents-realtime": "0.8.3",
+        "@openai/agents-core": "0.8.5",
+        "@openai/agents-openai": "0.8.5",
+        "@openai/agents-realtime": "0.8.5",
         "debug": "^4.4.0",
         "openai": "^6.26.0"
       },
@@ -1522,9 +1584,9 @@
       }
     },
     "node_modules/@openai/agents-core": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.8.3.tgz",
-      "integrity": "sha512-UWRwtGF4t+MkT2xMWTHuEUI2xgp58bKvMYN0rQu6rB9zWtiP0aY5tCXlWUdPKhpPlM/X68u6eUN7qDitqrf50g==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.8.5.tgz",
+      "integrity": "sha512-qs9mmN+D+UmqEZo3qrvhhIIXIOgSvJPic0v4a+ruq+eYgcQMk3PY8lLcsdQwJit6zf2Wyfv1q2cX5m3jzWZpKw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1542,13 +1604,43 @@
         }
       }
     },
-    "node_modules/@openai/agents-openai": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.8.3.tgz",
-      "integrity": "sha512-n5bsRfVDINupkeSh/E/lRoGWUi9xVSRpf6muRjnEckIO0pmCG3NzKO+FQVhiyFA3c8i2vrn28SXF/ZdGcG4+vQ==",
+    "node_modules/@openai/agents-extensions": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-extensions/-/agents-extensions-0.8.5.tgz",
+      "integrity": "sha512-uNnjQ+W84ir3UPn9tAIhnVTtnrgbxFuQVC8tENGUrLJRc4C1iT8Pfj6jiwXhfrU+AcGviNGnCK75umNuDo363g==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.8.3",
+        "@openai/agents-core": "0.8.5",
+        "@types/ws": "^8.18.1",
+        "debug": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@ai-sdk/provider": "^2.0.0 || ^3.0.0",
+        "@openai/agents": ">=0.0.0",
+        "@openai/codex-sdk": ">=0.86.0",
+        "ai": "^6.0.0",
+        "ws": "^8.18.1",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/provider": {
+          "optional": true
+        },
+        "@openai/codex-sdk": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openai/agents-openai": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.8.5.tgz",
+      "integrity": "sha512-cGYmyiVy8ecgf2Vch0L/ekeNo3xuZsuWnRsxyv+w9ai9dgxUifdEQ6G3dtsjMLtmXVHRVGoO7mVBr+tKcilntw==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.5",
         "debug": "^4.4.0",
         "openai": "^6.26.0"
       },
@@ -1557,18 +1649,27 @@
       }
     },
     "node_modules/@openai/agents-realtime": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.8.3.tgz",
-      "integrity": "sha512-no5AdAfYM5V/1u32OEQpP+VOJP/Y/JyTCVOvcgAdSKIV43ZG82f72pxbB0B2aFRdLZwC7C6sDgCJz6pbp+TjRg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.8.5.tgz",
+      "integrity": "sha512-JqKVsR33OvKtTxRp5Ylhw8WfNvJ49ZIhlhMZlSVKqwR2Ks6JuxqFJ0zM9p7JIbTQDSlAZnmnZJv1qlItaildiQ==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.8.3",
+        "@openai/agents-core": "0.8.5",
         "@types/ws": "^8.18.1",
         "debug": "^4.4.0",
         "ws": "^8.18.1"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -1966,6 +2067,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
@@ -3018,6 +3125,15 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
@@ -3251,6 +3367,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ai": {
+      "version": "6.0.170",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.170.tgz",
+      "integrity": "sha512-FWTKeGGDRcYJtPWIrdZDSuvOW5LCjI2NZUJmaml8OTOaPEsXnFdFvmawCXbT+wTGxyWKJTgZ9sZtCjbJsmjM2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.105",
+        "@ai-sdk/provider": "3.0.9",
+        "@ai-sdk/provider-utils": "4.0.24",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3287,9 +3421,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5145,11 +5279,10 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.7.tgz",
-      "integrity": "sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -5208,9 +5341,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5797,9 +5930,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -6178,9 +6311,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -6267,6 +6400,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6415,7 +6554,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6437,7 +6575,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6459,7 +6596,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6481,7 +6617,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6503,7 +6638,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6525,7 +6659,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6547,7 +6680,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6569,7 +6701,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6591,7 +6722,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6613,7 +6743,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6635,7 +6764,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10191,17 +10319,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10861,7 +10978,10 @@
       "name": "@before-that-resolves/server",
       "version": "1.1.0",
       "dependencies": {
-        "@openai/agents": "^0.8.3",
+        "@ai-sdk/anthropic": "^3.0.72",
+        "@openai/agents": "^0.8.5",
+        "@openai/agents-extensions": "^0.8.5",
+        "ai": "^6.0.170",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,10 @@
     "test:integration": "RUN_INTEGRATION_TESTS=1 vitest run"
   },
   "dependencies": {
-    "@openai/agents": "^0.8.3",
+    "@ai-sdk/anthropic": "^3.0.72",
+    "@openai/agents": "^0.8.5",
+    "@openai/agents-extensions": "^0.8.5",
+    "ai": "^6.0.170",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",

--- a/server/src/agents/card-oracle/index.test.ts
+++ b/server/src/agents/card-oracle/index.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Runner } from '@openai/agents';
+import type { AgentInputItem } from '@openai/agents';
+import { executeCardOracle } from './index';
+import { getConversationState, getHistory, setLastResponseId } from '../../utils/conversation-store';
+import { getOrCreateConversationId } from '../../utils/conversation-store';
+
+vi.mock('../../config/model-provider', () => ({
+  buildProviderConfig: vi.fn().mockReturnValue({ model: 'gpt-4o', runConfig: {} }),
+  OPENAI_DEFAULT_MODEL: 'gpt-4o',
+  ANTHROPIC_DEFAULT_MODEL: 'claude-sonnet-4-6'
+}));
+
+const fakeHistory: AgentInputItem[] = [
+  { role: 'user', content: 'What is Sol Ring?' } as AgentInputItem
+];
+
+const fakeRunResult = {
+  lastResponseId: 'resp_mock_123',
+  history: fakeHistory,
+  output: [{
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: 'A great mana rock.' }]
+  }],
+  newItems: [],
+  rawResponses: [],
+  state: {}
+};
+
+describe('executeCardOracle', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let runSpy: ReturnType<typeof vi.spyOn<any, any>>;
+
+  beforeEach(() => {
+    runSpy = vi.spyOn(Runner.prototype, 'run').mockResolvedValue(fakeRunResult as never);
+  });
+
+  describe('early error returns (no API calls)', () => {
+    it('returns openai error when apiKey is missing for openai', async () => {
+      const result = await executeCardOracle('test', false, 'conv-1', { provider: 'openai' });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('OpenAI');
+    });
+
+    it('returns anthropic error when apiKey is missing for anthropic', async () => {
+      const result = await executeCardOracle('test', false, 'conv-1', { provider: 'anthropic' });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Anthropic');
+    });
+
+    it('returns error when conversationId is missing', async () => {
+      const result = await executeCardOracle('test', false, undefined, { provider: 'openai', apiKey: 'sk-test' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('OpenAI conversation state', () => {
+    it('passes previousResponseId from store to runner', async () => {
+      const conversationId = getOrCreateConversationId();
+      setLastResponseId(conversationId, 'resp_prior_456');
+
+      await executeCardOracle('Hello', false, conversationId, { provider: 'openai', apiKey: 'sk-test' });
+
+      const callArgs = runSpy.mock.calls[0];
+      const runOptions = callArgs[2] as { previousResponseId?: string };
+      expect(runOptions.previousResponseId).toBe('resp_prior_456');
+    });
+
+    it('stores lastResponseId after run', async () => {
+      const conversationId = getOrCreateConversationId();
+
+      await executeCardOracle('Hello', false, conversationId, { provider: 'openai', apiKey: 'sk-test' });
+
+      expect(getConversationState(conversationId).openai?.lastResponseId).toBe('resp_mock_123');
+    });
+  });
+
+  describe('Anthropic conversation state', () => {
+    it('does not pass previousResponseId for anthropic', async () => {
+      const conversationId = getOrCreateConversationId();
+
+      await executeCardOracle('Hello', false, conversationId, { provider: 'anthropic', apiKey: 'sk-ant-test' });
+
+      const callArgs = runSpy.mock.calls[0];
+      const runOptions = callArgs[2] as { previousResponseId?: string };
+      expect(runOptions.previousResponseId).toBeUndefined();
+    });
+
+    it('stores result.history after run', async () => {
+      const conversationId = getOrCreateConversationId();
+
+      await executeCardOracle('Hello', false, conversationId, { provider: 'anthropic', apiKey: 'sk-ant-test' });
+
+      expect(getHistory(conversationId)).toEqual(fakeHistory);
+    });
+
+    it('prepends stored history to messages on subsequent turns', async () => {
+      const conversationId = getOrCreateConversationId();
+
+      // First turn — stores history
+      await executeCardOracle('Hello', false, conversationId, { provider: 'anthropic', apiKey: 'sk-ant-test' });
+
+      runSpy.mockClear();
+
+      // Second turn — should prepend stored history
+      await executeCardOracle('Follow up', false, conversationId, { provider: 'anthropic', apiKey: 'sk-ant-test' });
+
+      const callArgs = runSpy.mock.calls[0];
+      const messages = callArgs[1] as AgentInputItem[];
+      expect(messages.length).toBeGreaterThan(1);
+      expect(messages[0]).toEqual(fakeHistory[0]);
+      const lastMsg = messages[messages.length - 1] as { role: string; content: string };
+      expect(lastMsg.content).toBe('Follow up');
+    });
+  });
+});

--- a/server/src/agents/card-oracle/index.ts
+++ b/server/src/agents/card-oracle/index.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
-import { Agent, OpenAIProvider, Runner, type RunConfig } from '@openai/agents';
-import { openaiConfig } from '../../config/openai';
+import { Agent, Runner, type Model, type RunConfig } from '@openai/agents';
+import type { OracleModelSelection } from '../../types/provider';
+import { buildProviderConfig } from '../../config/model-provider';
 import {
   searchCardTool,
   cardCollectionTool,
@@ -14,7 +15,7 @@ import { createLoadedDeckTool, createLoadedDeckRawTool } from '../../tools/deck-
 import { createCommanderBracketTool } from '../../tools/bracket-tool';
 import { createGoldfishAgentTool } from '../../tools/goldfish-agent-tool';
 import { extractResponseText, countToolCalls, getToolCallDetails } from '../../utils/agent-helpers';
-import { getConversationState, setLastResponseId } from '../../utils/conversation-store';
+import { getConversationState, getHistory, setHistory, setLastResponseId } from '../../utils/conversation-store';
 
 export type ReasoningEffort = 'low' | 'medium' | 'high';
 type ModelSettingsReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | null;
@@ -33,17 +34,14 @@ export function toModelReasoningEffort(
 }
 
 function createCardOracleAgent(
-  model?: string,
-  reasoningEffort?: ReasoningEffort,
-  verbosity?: TextVerbosity,
-  runConfig?: Partial<RunConfig>,
-  conversationId?: string
+  resolvedModel: string | Model,
+  selection: OracleModelSelection,
+  runConfig: Partial<RunConfig>,
+  conversationId: string
 ) {
-  if (!conversationId) {
-    throw new Error('Conversation ID is required to create the Card Oracle agent.');
-  }
+  const { reasoningEffort, verbosity, provider } = selection;
   const normalizedEffort = toModelReasoningEffort(reasoningEffort);
-  const modelSettings = normalizedEffort || verbosity
+  const modelSettings = provider !== 'anthropic' && (normalizedEffort || verbosity)
     ? {
       ...(normalizedEffort ? { reasoning: { effort: normalizedEffort } } : {}),
       ...(verbosity ? { text: { verbosity } } : {})
@@ -52,7 +50,7 @@ function createCardOracleAgent(
 
   return new Agent({
     name: 'Card Oracle',
-    model: model || openaiConfig.model || 'gpt-4o',
+    model: resolvedModel,
     modelSettings,
     instructions: loadPrompt('card-oracle.md'),
     tools: [
@@ -64,8 +62,8 @@ function createCardOracleAgent(
       checkCommanderLegalityTool,
       createLoadedDeckTool(conversationId),
       createLoadedDeckRawTool(conversationId),
-      createCommanderBracketTool(model, reasoningEffort, verbosity, runConfig),
-      createGoldfishAgentTool(model, reasoningEffort, verbosity, runConfig, conversationId)
+      createCommanderBracketTool(resolvedModel, selection, runConfig),
+      createGoldfishAgentTool(resolvedModel, selection, runConfig, conversationId)
     ]
   });
 }
@@ -77,52 +75,54 @@ export async function executeCardOracle(
   query: string,
   devMode: boolean = false,
   conversationId?: string,
-  model?: string,
-  reasoningEffort?: ReasoningEffort,
-  verbosity?: TextVerbosity,
-  apiKey?: string
+  selection: OracleModelSelection = { provider: 'openai' }
 ) {
   console.log('🎴 Card Oracle Agent executing query:', query);
   const startTime = Date.now();
-  const resolvedKey = apiKey;
+  const { apiKey, provider } = selection;
 
   try {
-    if (!resolvedKey) {
+    if (!apiKey) {
       return {
         success: false,
-        error: 'OpenAI API key is required. Provide one in the UI.'
+        error: provider === 'anthropic'
+          ? 'Anthropic API key is required. Provide one in the UI.'
+          : 'OpenAI API key is required. Provide one in the UI.'
       };
     }
 
-    const runConfig: Partial<RunConfig> = {
-      modelProvider: new OpenAIProvider({ apiKey: resolvedKey })
-    };
-    const runOptions = conversationId
-      ? {
-        previousResponseId: getConversationState(conversationId).lastResponseId,
-        context: { model, reasoningEffort, verbosity },
+    if (!conversationId) {
+      return { success: false, error: 'Conversation ID is required.' };
+    }
+
+    const { model: resolvedModel, runConfig } = buildProviderConfig(selection);
+
+    const isAnthropic = provider === 'anthropic';
+    const existingHistory = isAnthropic ? getHistory(conversationId) : [];
+    const messages = existingHistory.length > 0
+      ? [...existingHistory, { role: 'user' as const, content: query }]
+      : [{ role: 'user' as const, content: query }];
+
+    const runOptions = isAnthropic
+      ? { context: { selection }, maxTurns: 100 }
+      : {
+        previousResponseId: getConversationState(conversationId).openai?.lastResponseId,
+        context: { selection },
         maxTurns: 100
-      }
-      : { context: { model, reasoningEffort, verbosity }, maxTurns: 100 };
+      };
+
     const cardOracleAgent = createCardOracleAgent(
-      model,
-      reasoningEffort,
-      verbosity,
+      resolvedModel,
+      selection,
       runConfig,
       conversationId
     );
     const runner = new Runner(runConfig);
-    const result = await runner.run(
-      cardOracleAgent,
-      [
-        {
-          role: 'user',
-          content: query
-        }
-      ],
-      runOptions
-    );
-    if (conversationId) {
+    const result = await runner.run(cardOracleAgent, messages, runOptions);
+
+    if (isAnthropic) {
+      setHistory(conversationId, result.history);
+    } else {
       setLastResponseId(conversationId, result.lastResponseId);
     }
 
@@ -169,10 +169,11 @@ export async function executeCardOracle(
   } catch (error: unknown) {
     const maybeError = error as { status?: number; response?: { status?: number }; message?: string };
     const status = maybeError?.status || maybeError?.response?.status;
+    const providerLabel = provider === 'anthropic' ? 'Anthropic' : 'OpenAI';
     const safeMessage =
       status === 401 || status === 403
-        ? 'OpenAI API key is invalid or unauthorized.'
-        : maybeError?.message || 'OpenAI request failed.';
+        ? `${providerLabel} API key is invalid or unauthorized.`
+        : maybeError?.message || `${providerLabel} request failed.`;
     console.error('❌ Card Oracle Agent error:', safeMessage);
     return {
       success: false,

--- a/server/src/agents/commander-bracket/index.test.ts
+++ b/server/src/agents/commander-bracket/index.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { createCommanderBracketAgent } from './index';
+import type { OracleModelSelection } from '../../types/provider';
+
+const openaiSelection: OracleModelSelection = {
+  provider: 'openai',
+  model: 'gpt-4o',
+  apiKey: 'sk-test',
+  reasoningEffort: 'high',
+  verbosity: 'high'
+};
+
+const anthropicSelection: OracleModelSelection = {
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-6',
+  apiKey: 'sk-ant-test',
+  reasoningEffort: 'high',
+  verbosity: 'high'
+};
+
+describe('createCommanderBracketAgent', () => {
+  it('uses the resolved model for agent construction', () => {
+    const agent = createCommanderBracketAgent('gpt-4o', openaiSelection);
+    expect(agent.model).toBe('gpt-4o');
+  });
+
+  it('applies reasoning and verbosity modelSettings for openai', () => {
+    const agent = createCommanderBracketAgent('gpt-4o', openaiSelection);
+    expect(agent.modelSettings?.reasoning?.effort).toBe('high');
+    expect(agent.modelSettings?.text?.verbosity).toBe('high');
+  });
+
+  it('strips reasoning and verbosity modelSettings for anthropic', () => {
+    const agent = createCommanderBracketAgent('claude-sonnet-4-6', anthropicSelection);
+    expect(agent.modelSettings?.reasoning).toBeUndefined();
+    expect(agent.modelSettings?.text?.verbosity).toBeUndefined();
+  });
+
+  it('omits modelSettings entirely when no reasoning or verbosity provided', () => {
+    const selection: OracleModelSelection = { provider: 'openai', apiKey: 'sk-test' };
+    const agent = createCommanderBracketAgent('gpt-4o', selection);
+    expect(agent.modelSettings?.reasoning).toBeUndefined();
+    expect(agent.modelSettings?.text?.verbosity).toBeUndefined();
+  });
+});

--- a/server/src/agents/commander-bracket/index.ts
+++ b/server/src/agents/commander-bracket/index.ts
@@ -1,8 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { Agent } from '@openai/agents';
-import { openaiConfig } from '../../config/openai';
-import type { ReasoningEffort, TextVerbosity } from '../card-oracle';
+import { Agent, type Model } from '@openai/agents';
+import type { OracleModelSelection } from '../../types/provider';
 import { toModelReasoningEffort } from '../card-oracle';
 
 function loadPrompt(filename: string): string {
@@ -11,12 +10,12 @@ function loadPrompt(filename: string): string {
 }
 
 export function createCommanderBracketAgent(
-  model?: string,
-  reasoningEffort?: ReasoningEffort,
-  verbosity?: TextVerbosity
+  resolvedModel: string | Model,
+  selection: OracleModelSelection
 ) {
+  const { reasoningEffort, verbosity, provider } = selection;
   const normalizedEffort = toModelReasoningEffort(reasoningEffort);
-  const modelSettings = normalizedEffort || verbosity
+  const modelSettings = provider !== 'anthropic' && (normalizedEffort || verbosity)
     ? {
       ...(normalizedEffort ? { reasoning: { effort: normalizedEffort } } : {}),
       ...(verbosity ? { text: { verbosity } } : {})
@@ -25,7 +24,7 @@ export function createCommanderBracketAgent(
 
   return new Agent({
     name: 'Commander Bracket Expert',
-    model: model || openaiConfig.model || 'gpt-4o',
+    model: resolvedModel,
     modelSettings,
     instructions: loadPrompt('commander-bracket.md')
   });

--- a/server/src/agents/goldfish/index.ts
+++ b/server/src/agents/goldfish/index.ts
@@ -1,8 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { Agent } from '@openai/agents';
-import { openaiConfig } from '../../config/openai';
-import type { ReasoningEffort, TextVerbosity } from '../card-oracle';
+import { Agent, type Model } from '@openai/agents';
+import type { OracleModelSelection } from '../../types/provider';
 import { toModelReasoningEffort } from '../card-oracle';
 import {
   createLoadDeckTool,
@@ -23,13 +22,13 @@ function loadPrompt(filename: string): string {
 }
 
 export function createGoldfishAgent(
-  model?: string,
-  reasoningEffort?: ReasoningEffort,
-  verbosity?: TextVerbosity,
+  resolvedModel: string | Model,
+  selection: OracleModelSelection,
   conversationId?: string
 ) {
+  const { reasoningEffort, verbosity, provider } = selection;
   const normalizedEffort = toModelReasoningEffort(reasoningEffort);
-  const modelSettings = normalizedEffort || verbosity
+  const modelSettings = provider !== 'anthropic' && (normalizedEffort || verbosity)
     ? {
       ...(normalizedEffort ? { reasoning: { effort: normalizedEffort } } : {}),
       ...(verbosity ? { text: { verbosity } } : {})
@@ -42,7 +41,7 @@ export function createGoldfishAgent(
 
   return new Agent({
     name: 'Commander Goldfish Expert',
-    model: model || openaiConfig.model || 'gpt-4o',
+    model: resolvedModel,
     modelSettings,
     instructions: loadPrompt('goldfish.md'),
     tools: [

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -30,10 +30,7 @@ describe('app routes', () => {
       'Hello there',
       false,
       'conv-123',
-      undefined,
-      undefined,
-      undefined,
-      testApiKey
+      { provider: 'openai', model: undefined, apiKey: testApiKey, reasoningEffort: undefined, verbosity: undefined }
     );
   });
 
@@ -62,10 +59,7 @@ describe('app routes', () => {
       'Ping',
       false,
       'conv-abc',
-      undefined,
-      undefined,
-      undefined,
-      testApiKey
+      { provider: 'openai', model: undefined, apiKey: testApiKey, reasoningEffort: undefined, verbosity: undefined }
     );
   });
 
@@ -91,6 +85,40 @@ describe('app routes', () => {
     expect(response.body.error).toBe('OpenAI API key is required. Provide one in the UI.');
   });
 
+  it('rejects anthropic queries without an anthropic key', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/api/agent/query')
+      .send({ query: 'Hello there', provider: 'anthropic' })
+      .expect(401);
+
+    expect(response.body.error).toBe('Anthropic API key is required. Provide one in the UI.');
+  });
+
+  it('forwards anthropic provider and key to the agent', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      success: true,
+      response: 'ok',
+      toolCalls: 0
+    });
+
+    const app = createApp({ executeCardOracle: execute });
+
+    await request(app)
+      .post('/api/agent/query')
+      .set('x-anthropic-key', 'sk-ant-test')
+      .send({ query: 'Hello there', provider: 'anthropic', model: 'claude-sonnet-4-6' })
+      .expect(200);
+
+    expect(execute).toHaveBeenCalledWith(
+      'Hello there',
+      false,
+      expect.any(String),
+      { provider: 'anthropic', model: 'claude-sonnet-4-6', apiKey: 'sk-ant-test', reasoningEffort: undefined, verbosity: undefined }
+    );
+  });
+
   it('passes through a per-request API key', async () => {
     const execute = vi.fn().mockResolvedValue({
       success: true,
@@ -112,10 +140,7 @@ describe('app routes', () => {
       'Hello there',
       false,
       expect.any(String),
-      undefined,
-      undefined,
-      undefined,
-      'sk-test'
+      { provider: 'openai', model: undefined, apiKey: 'sk-test', reasoningEffort: undefined, verbosity: undefined }
     );
   });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { executeCardOracle, exampleQueries } from './agents/card-oracle';
+import type { ModelProviderKind, OracleModelSelection } from './types/provider';
 import {
   cacheDeckFromUrl,
   fetchDeckImportCandidates as fetchDeckImportCandidatesService,
@@ -623,13 +624,16 @@ export function createApp(deps: AppDeps = {}) {
   });
 
   app.post('/api/agent/query', async (req, res) => {
-    const { query, devMode, conversationId, model, reasoningEffort, verbosity, deckUrl } = req.body;
+    const { query, devMode, conversationId, model, reasoningEffort, verbosity, deckUrl, provider } = req.body;
     const headerKey = req.header('x-openai-key');
+    const anthropicKey = req.header('x-anthropic-key');
     const authorization = req.header('authorization');
     const bearerKey = authorization?.startsWith('Bearer ')
       ? authorization.slice('Bearer '.length).trim()
       : undefined;
-    const requestApiKey = headerKey || bearerKey;
+
+    const resolvedProvider: ModelProviderKind = provider === 'anthropic' ? 'anthropic' : 'openai';
+    const requestApiKey = resolvedProvider === 'anthropic' ? anthropicKey : (headerKey || bearerKey);
 
     if (!query) {
       res.status(400).json({
@@ -641,10 +645,20 @@ export function createApp(deps: AppDeps = {}) {
     if (!requestApiKey) {
       res.status(401).json({
         success: false,
-        error: 'OpenAI API key is required. Provide one in the UI.'
+        error: resolvedProvider === 'anthropic'
+          ? 'Anthropic API key is required. Provide one in the UI.'
+          : 'OpenAI API key is required. Provide one in the UI.'
       });
       return;
     }
+
+    const selection: OracleModelSelection = {
+      provider: resolvedProvider,
+      model,
+      apiKey: requestApiKey,
+      reasoningEffort,
+      verbosity
+    };
 
     try {
       const activeConversationId = conversationId || getConversationId();
@@ -666,10 +680,7 @@ export function createApp(deps: AppDeps = {}) {
         query,
         devMode || false,
         activeConversationId,
-        model,
-        reasoningEffort,
-        verbosity,
-        requestApiKey
+        selection
       );
 
       res.json({ ...result, conversationId: activeConversationId });

--- a/server/src/config/model-provider.test.ts
+++ b/server/src/config/model-provider.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { OpenAIProvider } from '@openai/agents';
+import { AiSdkModel } from '@openai/agents-extensions/ai-sdk';
+import { buildProviderConfig, OPENAI_DEFAULT_MODEL } from './model-provider';
+
+describe('buildProviderConfig', () => {
+  describe('openai provider', () => {
+    it('returns a string model', () => {
+      const { model } = buildProviderConfig({ provider: 'openai', model: 'gpt-4o', apiKey: 'sk-test' });
+      expect(model).toBe('gpt-4o');
+    });
+
+    it('defaults to OPENAI_DEFAULT_MODEL when model not specified', () => {
+      const { model } = buildProviderConfig({ provider: 'openai', apiKey: 'sk-test' });
+      expect(model).toBe(OPENAI_DEFAULT_MODEL);
+    });
+
+    it('includes OpenAIProvider in runConfig', () => {
+      const { runConfig } = buildProviderConfig({ provider: 'openai', apiKey: 'sk-test' });
+      expect(runConfig.modelProvider).toBeInstanceOf(OpenAIProvider);
+    });
+  });
+
+  describe('anthropic provider', () => {
+    it('returns an AiSdkModel instance', () => {
+      const { model } = buildProviderConfig({ provider: 'anthropic', model: 'claude-sonnet-4-6', apiKey: 'sk-ant-test' });
+      expect(model).toBeInstanceOf(AiSdkModel);
+    });
+
+    it('defaults to ANTHROPIC_DEFAULT_MODEL when model not specified', () => {
+      const config = buildProviderConfig({ provider: 'anthropic', apiKey: 'sk-ant-test' });
+      expect(config.model).toBeInstanceOf(AiSdkModel);
+    });
+
+    it('returns empty runConfig (no modelProvider)', () => {
+      const { runConfig } = buildProviderConfig({ provider: 'anthropic', apiKey: 'sk-ant-test' });
+      expect(runConfig.modelProvider).toBeUndefined();
+    });
+  });
+});

--- a/server/src/config/model-provider.ts
+++ b/server/src/config/model-provider.ts
@@ -1,0 +1,32 @@
+import { OpenAIProvider, type Model, type RunConfig } from '@openai/agents';
+import { aisdk } from '@openai/agents-extensions/ai-sdk';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { openaiConfig } from './openai';
+import type { OracleModelSelection } from '../types/provider';
+
+export const ANTHROPIC_DEFAULT_MODEL = 'claude-sonnet-4-6';
+export const OPENAI_DEFAULT_MODEL = openaiConfig.model || 'gpt-4o';
+
+export type ProviderConfig = {
+  model: string | Model;
+  runConfig: Partial<RunConfig>;
+};
+
+export function buildProviderConfig(selection: OracleModelSelection): ProviderConfig {
+  const { provider, model, apiKey } = selection;
+
+  if (provider === 'anthropic') {
+    const anthropicProvider = createAnthropic({ apiKey });
+    return {
+      model: aisdk(anthropicProvider(model || ANTHROPIC_DEFAULT_MODEL)),
+      runConfig: {}
+    };
+  }
+
+  return {
+    model: model || OPENAI_DEFAULT_MODEL,
+    runConfig: {
+      modelProvider: new OpenAIProvider({ apiKey })
+    }
+  };
+}

--- a/server/src/integration/live-agent.test.ts
+++ b/server/src/integration/live-agent.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { run } from '@openai/agents';
 import { executeCardOracle } from '../agents/card-oracle';
 import { createGoldfishAgent } from '../agents/goldfish';
+import { buildProviderConfig } from '../config/model-provider';
 import { buildArchidektDeckData, cacheDeckFromUrl } from '../services/deck';
 import { countToolCalls, extractResponseText } from '../utils/agent-helpers';
 import { getOrCreateConversationId } from '../utils/conversation-store';
+import type { OracleModelSelection } from '../types/provider';
 
 const liveEnabled = process.env.RUN_LIVE_TESTS === '1';
 const openAiKey = process.env.OPENAI_API_KEY;
@@ -35,17 +37,14 @@ describeLive('live integrations', () => {
     'runs the agent with OpenAI conversation memory',
     async () => {
       const conversationId = getOrCreateConversationId();
-      const first = await executeCardOracle('What is Sol Ring?', false, conversationId, undefined, undefined, undefined, openAiKey);
+      const first = await executeCardOracle('What is Sol Ring?', false, conversationId, { provider: 'openai', apiKey: openAiKey });
       expect(first.success).toBe(true);
 
       const followUp = await executeCardOracle(
         'Summarize the previous answer in one sentence.',
         false,
         conversationId,
-        undefined,
-        undefined,
-        undefined,
-        openAiKey
+        { provider: 'openai', apiKey: openAiKey }
       );
       expect(followUp.success).toBe(true);
       expect(followUp.response).toBeTypeOf('string');
@@ -58,7 +57,9 @@ describeLive('live integrations', () => {
     'runs the goldfish agent tool chain against a live model',
     async () => {
       const conversationId = getOrCreateConversationId();
-      const agent = createGoldfishAgent(undefined, undefined, undefined, conversationId);
+      const selection: OracleModelSelection = { provider: 'openai', apiKey: openAiKey };
+      const { model: resolvedModel } = buildProviderConfig(selection);
+      const agent = createGoldfishAgent(resolvedModel, selection, conversationId);
       const prompt = [
         'Goldfish this Commander deck using the goldfish tools only:',
         'https://archidekt.com/decks/17352990/the_world_is_a_vampire',

--- a/server/src/test-agent.ts
+++ b/server/src/test-agent.ts
@@ -46,10 +46,7 @@ async function testCardOracle() {
         query,
         false,
         conversationId,
-        undefined,
-        undefined,
-        undefined,
-        openAiKey
+        { provider: 'openai', apiKey: openAiKey }
       );
 
       if (result.success && 'toolCalls' in result) {

--- a/server/src/tools/bracket-tool.ts
+++ b/server/src/tools/bracket-tool.ts
@@ -1,13 +1,13 @@
-import { type RunConfig } from '@openai/agents';
+import { type RunConfig, type Model } from '@openai/agents';
+import type { OracleModelSelection } from '../types/provider';
 import { createCommanderBracketAgent } from '../agents/commander-bracket';
 
 export function createCommanderBracketTool(
-  model?: string,
-  reasoningEffort?: 'low' | 'medium' | 'high',
-  verbosity?: 'low' | 'medium' | 'high',
+  resolvedModel: string | Model,
+  selection: OracleModelSelection,
   runConfig?: Partial<RunConfig>
 ) {
-  const agent = createCommanderBracketAgent(model, reasoningEffort, verbosity);
+  const agent = createCommanderBracketAgent(resolvedModel, selection);
   return agent.asTool({
     toolName: 'commander_bracket_expert',
     toolDescription: 'Answer questions about the Magic: The Gathering Commander bracket system',

--- a/server/src/tools/goldfish-agent-tool.ts
+++ b/server/src/tools/goldfish-agent-tool.ts
@@ -1,14 +1,14 @@
-import { type RunConfig } from '@openai/agents';
+import { type RunConfig, type Model } from '@openai/agents';
+import type { OracleModelSelection } from '../types/provider';
 import { createGoldfishAgent } from '../agents/goldfish';
 
 export function createGoldfishAgentTool(
-  model?: string,
-  reasoningEffort?: 'low' | 'medium' | 'high',
-  verbosity?: 'low' | 'medium' | 'high',
+  resolvedModel: string | Model,
+  selection: OracleModelSelection,
   runConfig?: Partial<RunConfig>,
   conversationId?: string
 ) {
-  const agent = createGoldfishAgent(model, reasoningEffort, verbosity, conversationId);
+  const agent = createGoldfishAgent(resolvedModel, selection, conversationId);
   return agent.asTool({
     toolName: 'commander_goldfish_expert',
     toolDescription: 'Goldfish a Commander deck using the goldfish simulator tools',

--- a/server/src/types/openai-agents-extensions-ai-sdk.d.ts
+++ b/server/src/types/openai-agents-extensions-ai-sdk.d.ts
@@ -1,0 +1,21 @@
+// Ambient declaration for @openai/agents-extensions/ai-sdk subpath export.
+// TypeScript's commonjs moduleResolution doesn't resolve package exports maps,
+// so we declare the public surface we use directly.
+declare module '@openai/agents-extensions/ai-sdk' {
+  import type {
+    Model,
+    ModelRequest,
+    ModelResponse,
+    ModelRetryAdvice,
+    ModelRetryAdviceRequest,
+    StreamEvent,
+  } from '@openai/agents';
+
+  export class AiSdkModel implements Model {
+    getResponse(request: ModelRequest): Promise<ModelResponse>;
+    getStreamedResponse(request: ModelRequest): AsyncIterable<StreamEvent>;
+    getRetryAdvice?(args: ModelRetryAdviceRequest): Promise<ModelRetryAdvice | undefined> | ModelRetryAdvice | undefined;
+  }
+
+  export function aisdk(model: unknown): AiSdkModel;
+}

--- a/server/src/types/provider.ts
+++ b/server/src/types/provider.ts
@@ -1,0 +1,9 @@
+export type ModelProviderKind = 'openai' | 'anthropic';
+
+export type OracleModelSelection = {
+  provider: ModelProviderKind;
+  model?: string;
+  apiKey?: string;
+  reasoningEffort?: 'low' | 'medium' | 'high';
+  verbosity?: 'low' | 'medium' | 'high';
+};

--- a/server/src/utils/conversation-store.test.ts
+++ b/server/src/utils/conversation-store.test.ts
@@ -1,32 +1,82 @@
 import { describe, expect, it } from 'vitest';
+import type { AgentInputItem } from '@openai/agents';
 import {
   getConversationState,
+  getHistory,
   getOrCreateConversationId,
   resetConversation,
+  setHistory,
   setLastResponseId
 } from './conversation-store';
 
 describe('conversation-store', () => {
-  it('creates and retrieves conversation state', () => {
-    const conversationId = getOrCreateConversationId();
-    const state = getConversationState(conversationId);
+  describe('OpenAI state', () => {
+    it('creates and retrieves conversation state', () => {
+      const conversationId = getOrCreateConversationId();
+      const state = getConversationState(conversationId);
 
-    expect(state).toBeDefined();
-    expect(state.lastResponseId).toBeUndefined();
+      expect(state).toBeDefined();
+      expect(state.openai?.lastResponseId).toBeUndefined();
 
-    setLastResponseId(conversationId, 'resp_123');
-    const updated = getConversationState(conversationId);
-    expect(updated.lastResponseId).toBe('resp_123');
+      setLastResponseId(conversationId, 'resp_123');
+      const updated = getConversationState(conversationId);
+      expect(updated.openai?.lastResponseId).toBe('resp_123');
+    });
+
+    it('ignores setLastResponseId when value is undefined', () => {
+      const conversationId = getOrCreateConversationId();
+      setLastResponseId(conversationId, 'resp_111');
+      setLastResponseId(conversationId, undefined);
+      expect(getConversationState(conversationId).openai?.lastResponseId).toBe('resp_111');
+    });
   });
 
-  it('resets conversation state', () => {
-    const conversationId = getOrCreateConversationId();
-    setLastResponseId(conversationId, 'resp_456');
+  describe('Anthropic history state', () => {
+    it('returns empty array when no history is stored', () => {
+      const conversationId = getOrCreateConversationId();
+      expect(getHistory(conversationId)).toEqual([]);
+    });
 
-    const cleared = resetConversation(conversationId);
-    expect(cleared).toBe(true);
+    it('stores and retrieves history', () => {
+      const conversationId = getOrCreateConversationId();
+      const history = [
+        { role: 'user', content: 'What is Sol Ring?' },
+        { role: 'assistant', content: [{ type: 'output_text', text: 'Sol Ring is a mana rock.' }] }
+      ] as AgentInputItem[];
 
-    const clearedAgain = resetConversation(conversationId);
-    expect(clearedAgain).toBe(false);
+      setHistory(conversationId, history);
+      expect(getHistory(conversationId)).toEqual(history);
+    });
+
+    it('replaces history on subsequent calls', () => {
+      const conversationId = getOrCreateConversationId();
+      const firstHistory = [{ role: 'user', content: 'First' }] as AgentInputItem[];
+      const secondHistory = [
+        { role: 'user', content: 'First' },
+        { role: 'assistant', content: [{ type: 'output_text', text: 'Reply' }] },
+        { role: 'user', content: 'Second' }
+      ] as AgentInputItem[];
+
+      setHistory(conversationId, firstHistory);
+      setHistory(conversationId, secondHistory);
+      expect(getHistory(conversationId)).toEqual(secondHistory);
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all state including openai and history', () => {
+      const conversationId = getOrCreateConversationId();
+      setLastResponseId(conversationId, 'resp_456');
+      setHistory(conversationId, [{ role: 'user', content: 'Hello' }] as AgentInputItem[]);
+
+      const cleared = resetConversation(conversationId);
+      expect(cleared).toBe(true);
+
+      const clearedAgain = resetConversation(conversationId);
+      expect(clearedAgain).toBe(false);
+
+      expect(getConversationState(conversationId).openai).toBeUndefined();
+      expect(getHistory(conversationId)).toEqual([]);
+    });
   });
 });

--- a/server/src/utils/conversation-store.ts
+++ b/server/src/utils/conversation-store.ts
@@ -1,7 +1,11 @@
 import crypto from 'crypto';
+import type { AgentInputItem } from '@openai/agents';
 
 type ConversationState = {
-  lastResponseId?: string;
+  openai?: {
+    lastResponseId?: string;
+  };
+  history?: AgentInputItem[];
 };
 
 const conversations = new Map<string, ConversationState>();
@@ -24,7 +28,16 @@ export function getConversationState(conversationId: string): ConversationState 
 export function setLastResponseId(conversationId: string, lastResponseId?: string) {
   if (!lastResponseId) return;
   const state = getConversationState(conversationId);
-  state.lastResponseId = lastResponseId;
+  state.openai = { ...state.openai, lastResponseId };
+}
+
+export function setHistory(conversationId: string, history: AgentInputItem[]) {
+  const state = getConversationState(conversationId);
+  state.history = history;
+}
+
+export function getHistory(conversationId: string): AgentInputItem[] {
+  return getConversationState(conversationId).history ?? [];
 }
 
 export function resetConversation(conversationId: string): boolean {


### PR DESCRIPTION
## Summary

- Adds Anthropic Claude as a selectable LLM provider alongside the existing OpenAI path
- Provider, model, and API key are chosen per-session in the UI — no server-side key configuration required
- All existing OpenAI behaviour is preserved unchanged; Anthropic is purely additive
- Fixes pre-existing client test failures caused by jsdom 25 breaking the built-in localStorage implementation

## What changed

**Server**
- `server/src/types/provider.ts` — `ModelProviderKind` and `OracleModelSelection` types
- `server/src/config/model-provider.ts` — factory resolving a selection into a model instance + RunConfig; uses `aisdk()` from `@openai/agents-extensions` to wrap `@ai-sdk/anthropic` models for the OpenAI Agents SDK
- `server/src/utils/conversation-store.ts` — provider-aware state: OpenAI uses `previousResponseId`; Anthropic accumulates full `AgentInputItem[]` history passed on each subsequent turn
- All agents (Card Oracle, Commander Bracket, Goldfish) receive the resolved model from the factory; `reasoningEffort` and `verbosity` are stripped server-side for Anthropic
- `/api/agent/query` now accepts `provider` in the body and `x-anthropic-key` alongside `x-openai-key`

**Client**
- Provider segmented control (OpenAI / Anthropic) in AI Options panel
- Provider-specific API key input, model list, and localStorage persistence
- Switching providers resets the conversation ID for a clean slate

**Documentation**
- README, AGENTS.md, docs/ updated for both providers

## Approach and decisions

- **AI SDK adapter**: `@openai/agents-extensions` v0.8.5 `aisdk()` wraps any Vercel AI SDK model to work transparently with the OpenAI Agents SDK — no agent loop rewrite required
- **Separate conversation history**: OpenAI keeps `previousResponseId`; Anthropic stores `result.history` and prepends it to each subsequent request
- **Single factory call per request**: `buildProviderConfig` is called once in `executeCardOracle`; the resolved model and runConfig flow to all sub-agents
- **Settings filtering**: `reasoningEffort`/`verbosity` are OpenAI-only; agent constructors check `provider !== 'anthropic'` before applying modelSettings
- **TypeScript subpath resolution**: `@openai/agents-extensions/ai-sdk` is a package subpath that `commonjs` moduleResolution can't resolve; an ambient declaration in `server/src/types/` provides the types without changing module resolution globally

## Test coverage

135 tests pass (87 server, 48 client), 0 failures.

New tests: `model-provider.test.ts`, `card-oracle/index.test.ts`, `commander-bracket/index.test.ts`  
Updated: `app.test.ts`, `conversation-store.test.ts`  
Client fix: added localStorage mock to `client/src/test/setup.ts` — jsdom 25 removed the built-in implementation, silently breaking all 45 component/hook tests

## Testing requests for reviewers

The following paths require a real API key and could not be verified locally — any help before merge is much appreciated:

- [ ] **OpenAI regression** — basic query, multi-turn context, deck analysis, Commander Bracket and Goldfish sub-agents
- [ ] **Anthropic basic query** — ask "What is Lightning Bolt?" with a Claude key; confirm a response arrives
- [ ] **Anthropic tool use** — ask a card question; confirm Scryfall tool is called and card data appears in the answer
- [ ] **Anthropic multi-turn** — ask a follow-up without repeating context; confirm history carries across turns
- [ ] **Anthropic sub-agents** — ask a bracket question; confirm Commander Bracket Expert responds
- [ ] **Goldfish with Anthropic** — load a deck and run a simulation; highest-risk path (`agent.asTool()` with AI SDK adapter)
- [ ] **Provider switch** — switch from OpenAI to Anthropic mid-session; confirm conversation resets cleanly

To run the gated Anthropic live tests:
```bash
# macOS/Linux
export ANTHROPIC_API_KEY="sk-ant-..."
RUN_ANTHROPIC_LIVE_TESTS=1 npm run test:live --workspace=server

# Windows (PowerShell)
$env:ANTHROPIC_API_KEY="sk-ant-..."
$env:RUN_ANTHROPIC_LIVE_TESTS="1"
npm run test:live --workspace=server
